### PR TITLE
TwoSurfaceHeadModel: make landmarks optional

### DIFF
--- a/src/cedalion/dataclasses/geometry.py
+++ b/src/cedalion/dataclasses/geometry.py
@@ -129,7 +129,12 @@ class TrimeshSurface(Surface):
             The surface with a decimated mesh
         """
 
-        decimated = self.mesh.simplify_quadric_decimation(face_count)
+        try:
+            decimated = self.mesh.simplify_quadric_decimation(face_count)
+        except:
+            # deprecated trimesh function, please update trimesh!
+            decimated = self.mesh.simplify_quadratic_decimation(face_count)
+
         return TrimeshSurface(decimated, self.crs, self.units)
 
     def smooth(self, lamb: float) -> "TrimeshSurface":

--- a/src/cedalion/imagereco/forward_model.py
+++ b/src/cedalion/imagereco/forward_model.py
@@ -27,7 +27,7 @@ class TwoSurfaceHeadModel:
     segmentation_masks: xr.DataArray
     brain: cdc.Surface
     scalp: cdc.Surface
-    landmarks: cdt.LabeledPointCloud
+    landmarks: Optional[cdt.LabledPointCloud]
     t_ijk2ras: cdt.AffineTransform
     t_ras2ijk: cdt.AffineTransform
     voxel_to_vertex_brain: scipy.sparse.spmatrix


### PR DESCRIPTION
It would be great if landmarks could not be a necessary property in order to construct a headmodel instance. For exemaple if
-  I don't have an MRI, but exact optodes from photogrammetry. I bring my meshes with me (from warping, or other studies, or I have my standard head from own segmentation) and have the aligned optode positions / montage I always use...
- Or I don't have MRI, I don't have exact optode positions but my own montage -> I use cedalion.datasets.get_colin27_segmentation() + my montage file on colin. 

Old use case is still working:
- I have MRI, I have masks, I have landmarks, all good. 

I propose asking the user to add landmarks to the instance at the point where they are needed.