### PR TITLE
Change surface mesh decimation to vtk based algorithm

### DIFF
--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -55,4 +55,3 @@ dependencies:
       - setuptools-scm==7.1.0
       - snirf==0.7.4
       - pmcx
-      - open3d==0.16

--- a/src/cedalion/dataclasses/geometry.py
+++ b/src/cedalion/dataclasses/geometry.py
@@ -8,6 +8,7 @@ import numpy as np
 import pint
 import trimesh
 import vtk
+import mne
 import xarray as xr
 from scipy.spatial import KDTree
 from vtk.util.numpy_support import vtk_to_numpy
@@ -129,12 +130,11 @@ class TrimeshSurface(Surface):
             The surface with a decimated mesh
         """
 
-        try:
-            decimated = self.mesh.simplify_quadric_decimation(face_count)
-        except:
-            # deprecated trimesh function, please update trimesh!
-            decimated = self.mesh.simplify_quadratic_decimation(face_count)
-
+        vertices, faces = mne.decimate_surface(self.mesh.vertices,
+                                               self.mesh.faces, face_count,
+                                               method="quadric")
+        decimated = trimesh.Trimesh(vertices, faces)
+        
         return TrimeshSurface(decimated, self.crs, self.units)
 
     def smooth(self, lamb: float) -> "TrimeshSurface":

--- a/src/cedalion/imagereco/forward_model.py
+++ b/src/cedalion/imagereco/forward_model.py
@@ -27,7 +27,7 @@ class TwoSurfaceHeadModel:
     segmentation_masks: xr.DataArray
     brain: cdc.Surface
     scalp: cdc.Surface
-    landmarks: Optional[cdt.LabledPointCloud]
+    landmarks: Optional[cdt.LabeledPointCloud]
     t_ijk2ras: cdt.AffineTransform
     t_ras2ijk: cdt.AffineTransform
     voxel_to_vertex_brain: scipy.sparse.spmatrix


### PR DESCRIPTION
Is there any reason why we used the surface mesh decimation algorithm of open3D?
Cedalion has a huge dependency list already and open3D is somehow annoying to install on MacOS and I also had some issues installing it in a singularity container for running it on the HPC (due to libgomp1). Surface mesh decimation algorithms exist for example also by vtk or in mne (which calls vtk). Both are already dependencies of cedalion.
Mesh quality is the same (both implementations use Quadric Error Metric Decimation).

I also corrected a typo in `src/cedalion/imagereco/forward_model.py` from [PR#3](https://github.com/ibs-lab/cedalion/pull/3).