### PR TITLE
add 2d geometry capability to read_snirf and beer_lambert functions

### DIFF
--- a/src/cedalion/io/snirf.py
+++ b/src/cedalion/io/snirf.py
@@ -196,13 +196,18 @@ def reduce_ndim_sourceLabels(sourceLabels: np.ndarray) -> list:
     return labels
 
 
-def labels_and_positions(probe):
+def labels_and_positions(probe, dim: int = 3):
     def convert_none(probe, attrname, default):
         attr = getattr(probe, attrname)
         if attr is None:
             return default
         else:
             return attr
+
+    if dim not in [2, 3]:
+        raise AttributeError(f"dim must be '2' or '3' but got {dim}")
+    else:
+        dim = int(dim)
 
     sourceLabels = convert_none(probe, "sourceLabels", np.asarray([], dtype=str))
     detectorLabels = convert_none(probe, "detectorLabels", np.asarray([], dtype=str))
@@ -211,34 +216,38 @@ def labels_and_positions(probe):
     if sourceLabels.ndim > 1:
         sourceLabels = reduce_ndim_sourceLabels(sourceLabels)
 
-    sourcePos3D = convert_none(probe, "sourcePos3D", np.zeros((0, 3)))
-    detectorPos3D = convert_none(probe, "detectorPos3D", np.zeros((0, 3)))
-    landmarkPos3D = convert_none(probe, "landmarkPos3D", np.zeros((0, 3)))[
-        :, :3
+    sourcePos = convert_none(probe, f"sourcePos{dim}D", np.zeros((0, dim)))
+    detectorPos = convert_none(probe, f"detectorPos{dim}D", np.zeros((0, dim)))
+    landmarkPos = convert_none(probe, f"landmarkPos{dim}D", np.zeros((0, dim + 1)))[
+        :, :dim
     ]  # FIXME we keep only the positional columns
 
-    if len(sourcePos3D) > 0 and len(sourceLabels) == 0:
+    if len(sourcePos) > 0 and len(sourceLabels) == 0:
         log.warning("generating generic source labels")
-        sourceLabels = np.asarray([f"S{i+1}" for i in range(len(sourcePos3D))])
+        sourceLabels = np.asarray([f"S{i+1}" for i in range(len(sourcePos))])
 
-    if len(detectorPos3D) > 0 and len(detectorLabels) == 0:
+    if len(detectorPos) > 0 and len(detectorLabels) == 0:
         log.warning("generating generic detector labels")
-        detectorLabels = np.asarray([f"D{i+1}" for i in range(len(detectorPos3D))])
+        detectorLabels = np.asarray([f"D{i+1}" for i in range(len(detectorPos))])
 
-    if len(landmarkLabels) != len(landmarkPos3D):
-        raise ValueError("landmark positions were provided but no labels")
+    if len(landmarkPos) != len(landmarkLabels):
+        if len(landmarkPos) > 0:
+            raise ValueError("landmark positions were provided but no labels")
+        else:
+            log.warning("landmark labels were provided but not their positions. Removing labels")
+            landmarkLabels = np.asarray([], dtype=str)
 
     return (
         sourceLabels,
         detectorLabels,
         landmarkLabels,
-        sourcePos3D,
-        detectorPos3D,
-        landmarkPos3D,
+        sourcePos,
+        detectorPos,
+        landmarkPos,
     )
 
 
-def geometry_from_probe(nirs_element: NirsElement):
+def geometry_from_probe(nirs_element: NirsElement, dim: int = 3):
     probe = nirs_element.probe
 
     length_unit = nirs_element.metaDataTags.LengthUnit
@@ -247,10 +256,10 @@ def geometry_from_probe(nirs_element: NirsElement):
         sourceLabels,
         detectorLabels,
         landmarkLabels,
-        sourcePos3D,
-        detectorPos3D,
-        landmarkPos3D,
-    ) = labels_and_positions(probe)
+        sourcePos,
+        detectorPos,
+        landmarkPos,
+    ) = labels_and_positions(probe, dim)
 
     types = (
         [PointType.SOURCE] * len(sourceLabels)
@@ -259,7 +268,7 @@ def geometry_from_probe(nirs_element: NirsElement):
     )
 
     labels = np.hstack([sourceLabels, detectorLabels, landmarkLabels])
-    positions = np.vstack([sourcePos3D, detectorPos3D, landmarkPos3D])
+    positions = np.vstack([sourcePos, detectorPos, landmarkPos])
 
     coords = {"label": ("label", labels), "type": ("label", types)}
     dims = ["label", "pos"]
@@ -523,7 +532,8 @@ def _get_channel_coords(
 
 
 def read_nirs_element(nirs_element, opts):
-    geo3d = geometry_from_probe(nirs_element)
+    geo2d = geometry_from_probe(nirs_element, dim=2)
+    geo3d = geometry_from_probe(nirs_element, dim=3)
     stim = stim_to_dataframe(nirs_element.stim)
     data = []
     for data_element in nirs_element.data:
@@ -543,8 +553,8 @@ def read_nirs_element(nirs_element, opts):
         measurement_lists.append(df_ml)
 
     ne = Element(
-        data, stim, geo3d, None, aux, meta_data, measurement_lists
-    )  # FIXME geo2d
+        data, stim, geo3d, geo2d, aux, meta_data, measurement_lists
+    )
 
     return ne
 

--- a/src/cedalion/nirs.py
+++ b/src/cedalion/nirs.py
@@ -65,22 +65,26 @@ def get_extinction_coefficients(spectrum: str, wavelengths: ArrayLike):
         raise ValueError(f"unsupported spectrum '{spectrum}'")
 
 
-def channel_distances(amplitudes: xr.DataArray, geo3d: xr.DataArray):
+def channel_distances(amplitudes: xr.DataArray, geo: xr.DataArray, dim: int = 3):
     """Calculate distances between channels.
 
     Args:
-        amplitudes (xr.DataArray): A DataArray representing the amplitudes with dimensions (channel, *).
-        geo3d (xr.DataArray): A DataArray containing the 3D coordinates of the channels with dimensions (channel, pos).
+        amplitudes (xr.DataArray): A DataArray representing the amplitudes
+            with dimensions (channel, *).
+        geo (xr.DataArray): A DataArray containing the 2D or 3D coordinates of
+            the channels with dimensions (channel, pos).
+        dim (int, optional): Geometry dimension, must be 2 or 3. Default 3.
 
     Returns:
-        dists (xr.DataArray): A DataArray containing the calculated distances between source and detector channels. 
-            The resulting DataArray has the dimension 'channel'.
+        dists (xr.DataArray): A DataArray containing the calculated distances
+            between source and detector channels. The resulting DataArray
+            has the dimension 'channel'.
     """
     validators.has_channel(amplitudes)
-    validators.has_positions(geo3d, npos=3)
-    validators.is_quantified(geo3d)
+    validators.has_positions(geo, npos=dim)
+    validators.is_quantified(geo)
 
-    diff = geo3d.loc[amplitudes.source] - geo3d.loc[amplitudes.detector]
+    diff = geo.loc[amplitudes.source] - geo.loc[amplitudes.detector]
     dists = xrutils.norm(diff, "pos")
     dists = dists.rename("dists")
 
@@ -102,18 +106,20 @@ def int2od(amplitudes: xr.DataArray):
 
 def od2conc(
     od: xr.DataArray,
-    geo3d: xr.DataArray,
+    geo: xr.DataArray,
     dpf: xr.DataArray,
     spectrum: str = "prahl",
+    dim: int = 3
 ):
     """Calculate concentration changes from optical density data.
 
     Args:
         od (xr.DataArray, (channel, wavelength, *)): The optical density data array
-        geo3d (xr.DataArray): The 3D coordinates of the optodes.
+        geo (xr.DataArray): The 2D or 3D coordinates of the optodes.
         dpf (xr.DataArray, (wavelength, *)): The differential pathlength factor data
         spectrum (str, optional): The type of spectrum to use for calculating extinction
             coefficients. Defaults to "prahl".
+        dim (int, optional): Geometry dimension, must be 2 or 3. Default 3.
 
     Returns:
         conc (xr.DataArray, (channel, wavelength, *)): A data array containing 
@@ -122,13 +128,13 @@ def od2conc(
     validators.has_channel(od)
     validators.has_wavelengths(od)
     validators.has_wavelengths(dpf)
-    validators.has_positions(geo3d, npos=3)
+    validators.has_positions(geo, npos=dim)
 
     E = get_extinction_coefficients(spectrum, od.wavelength)
 
     Einv = xrutils.pinv(E)
 
-    dists = channel_distances(od, geo3d)
+    dists = channel_distances(od, geo, dim)
     dists = dists.pint.to("mm")
 
     # conc = Einv @ (optical_density / ( dists * dpf))
@@ -141,31 +147,39 @@ def od2conc(
 
 def beer_lambert(
     amplitudes: xr.DataArray,
-    geo3d: xr.DataArray,
+    geo: xr.DataArray,
     dpf: xr.DataArray,
     spectrum: str = "prahl",
+    dim: int = 3,
 ):
     """Calculate concentration changes from amplitude data using the modified beer-lambert law.
 
     Args:
         amplitudes (xr.DataArray, (channel, wavelength, *)): The input data array containing the raw intensities.
-        geo3d (xr.DataArray): The 3D coordinates of the optodes.
+        geo (xr.DataArray): The 2D or 3D coordinates of the optodes.
         dpf (xr.DataArray, (wavelength,*)): The differential pathlength factors
         spectrum (str, optional): The type of spectrum to use for calculating extinction
             coefficients. Defaults to "prahl".
+        dim (int, optional): Geometry dimension, must be 2 or 3. Default 3.
 
     Returns:
         conc (xr.DataArray, (channel, wavelength, *)): A data array containing concentration 
             changes according to the mBLL
     """
+
+    if dim not in [2, 3]:
+        raise AttributeError(f"dim must be '2' or '3' but got {dim}")
+    else:
+        dim = int(dim)
+
     validators.has_channel(amplitudes)
     validators.has_wavelengths(amplitudes)
     validators.has_wavelengths(dpf)
-    validators.has_positions(geo3d, npos=3)
+    validators.has_positions(geo, npos=dim)
 
     # calculate optical densities
     od = int2od(amplitudes)
     # calculate concentrations
-    conc = od2conc(od, geo3d, dpf, spectrum)
+    conc = od2conc(od, geo, dpf, spectrum, dim)
 
     return conc


### PR DESCRIPTION
I was playing around with the resting state dataset I and I realized that the read_snirf function from cedalion didn't work when optode locations were given in a 2D space (rather than in 3D).

--**snirf.py file**--

There was a FIXME: geo2d comment at the end of the read_nirs_element function, which I think it was referring to exactly this problem, right?

I modified the geometry_from_probe function (and some functions used inside it) so it does the same as it was doing before for 3D coordinates only but now also for 2D. The "dim" argument chooses whether we want the 2D or 3D info from the nirs element. 

With this new geometry_from_probe function then I just used it twice inside read_nirs_element to get geo3d and geo2d. The resulting Element now has both attributes. I checked with the Stroop dataset, which has both 2d and 3d information, and the resulting Element seems to be working as expected: it has both geo2d and geo3d non-trivial (i.e. not None type) attributes.

--**nirs.py file**--

With a similar philosophy, I modified the beer_lambert function so it can handle 2d locations (by passing the dim=2) argument. If I understood the logic of the function correctly, the only difference now is that the distance within optodes is computed with a norm over 2d vectors, instead of 3d.
