### PR TITLE
Add Support for NIRFASTer and MCX in Light Propagation Simulation

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install nirfaster
         run: |
-           ./install_nirfaster.sh CPU
+           bash install_nirfaster.sh CPU
 
       - name: Building docs
         run: |

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install nirfaster
         run: |
-           install_nirfaster.sh CPU
+           ./install_nirfaster.sh CPU
 
       - name: Building docs
         run: |

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -39,6 +39,10 @@ jobs:
         run: |
            python -m pip install -e . --no-deps --force-reinstall
 
+      - name: Install nirfaster
+        run: |
+           bash install_nirsfaster.sh CPU
+
       - name: Building docs
         run: |
           ./scripts/build_docs.sh docs

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install nirfaster
         run: |
-           bash install_nirsfaster.sh CPU
+           bash install_nirfaster.sh CPU
 
       - name: Building docs
         run: |

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Install nirfaster
         run: |
            bash install_nirfaster.sh CPU
+        shell: bash
 
       - name: Building docs
         run: |

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install nirfaster
         run: |
-           bash install_nirfaster.sh CPU
+           install_nirfaster.sh CPU
 
       - name: Building docs
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install nirfaster
         run: |
-           bash install_nirfaster.sh CPU
+           install_nirfaster.sh CPU
 
       - name: Running Tests
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Install nirfaster
         run: |
            bash install_nirfaster.sh CPU
+        shell: bash
 
       - name: Running Tests
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install nirfaster
         run: |
-           bash install_nirsfaster.sh CPU
+           bash install_nirfaster.sh CPU
 
       - name: Running Tests
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install nirfaster
         run: |
-           install_nirfaster.sh CPU
+           ./install_nirfaster.sh CPU
 
       - name: Running Tests
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -26,6 +26,10 @@ jobs:
         run: |
            python -m pip install -e . --no-deps --force-reinstall
 
+      - name: Install nirfaster
+        run: |
+           bash install_nirsfaster.sh CPU
+
       - name: Running Tests
         run: |
           python -m pytest --verbose

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -28,8 +28,8 @@ jobs:
 
       - name: Install nirfaster
         run: |
-           ./install_nirfaster.sh CPU
+           bash install_nirfaster.sh CPU
 
       - name: Running Tests
         run: |
-          python -m pytest --verbose
+           python -m pytest --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ scratch/
 src/FTanalysis_full.ipynb
 src/FTanalysis_full.ipynb
 src/FTanalysis_full.ipynb
+
+# plugins
+plugins/

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ $ conda env create -n cedalion -f environment_dev.yml
 Afterwards activate the environment and add an editable install of `cedalion` to it:
 ```
 $ conda activate cedalion
-$ bash install_nirsfaster.sh CPU # or GPU
 $ pip install -e .
+$ bash install_nirsfaster.sh CPU # or GPU
 ```
 
 This will also install Jupyter Notebook to run the example notebooks.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Afterwards activate the environment and add an editable install of `cedalion` to
 ```
 $ conda activate cedalion
 $ pip install -e .
-$ bash install_nirsfaster.sh CPU # or GPU
+$ bash install_nirfaster.sh CPU # or GPU
 ```
 
 This will also install Jupyter Notebook to run the example notebooks.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ $ conda env create -n cedalion -f environment_dev.yml
 Afterwards activate the environment and add an editable install of `cedalion` to it:
 ```
 $ conda activate cedalion
+$ bash install_nirsfaster.sh CPU # or GPU
 $ pip install -e .
 ```
 

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -127,3 +127,46 @@ issn={1662-5196},
 
 abstract={<p>Surface visualizations of fMRI provide a comprehensive view of cortical activity. However, surface visualizations are difficult to generate and most common visualization techniques rely on unnecessary interpolation which limits the fidelity of the resulting maps. Furthermore, it is difficult to understand the relationship between flattened cortical surfaces and the underlying 3D anatomy using tools available currently. To address these problems we have developed pycortex, a Python toolbox for interactive surface mapping and visualization. Pycortex exploits the power of modern graphics cards to sample volumetric data on a per-pixel basis, allowing dense and accurate mapping of the voxel grid across the surface. Anatomical and functional information can be projected onto the cortical surface. The surface can be inflated and flattened interactively, aiding interpretation of the correspondence between the anatomical surface and the flattened cortical sheet. The output of pycortex can be viewed using WebGL, a technology compatible with modern web browsers. This allows complex fMRI surface maps to be distributed broadly online without requiring installation of complex software.</p>}}
 
+@article{fang2009monte,
+  title={Monte Carlo simulation of photon migration in 3D turbid media accelerated by graphics processing units},
+  author={Fang, Qianqian and Boas, David A},
+  journal={Optics express},
+  volume={17},
+  number={22},
+  pages={20178--20190},
+  year={2009},
+  publisher={Optica Publishing Group}
+}
+
+@article{yu2018scalable,
+  title={Scalable and massively parallel Monte Carlo photon transport simulations for heterogeneous computing platforms},
+  author={Yu, Leiming and Nina-Paravecino, Fanny and Kaeli, David and Fang, Qianqian},
+  journal={Journal of biomedical optics},
+  volume={23},
+  number={1},
+  pages={010504--010504},
+  year={2018},
+  publisher={Society of Photo-Optical Instrumentation Engineers}
+}
+
+@article{yan2020hybrid,
+  title={Hybrid mesh and voxel based Monte Carlo algorithm for accurate and efficient photon transport modeling in complex bio-tissues},
+  author={Yan, Shijie and Fang, Qianqian},
+  journal={Biomedical Optics Express},
+  volume={11},
+  number={11},
+  pages={6262--6270},
+  year={2020},
+  publisher={Optica Publishing Group}
+}
+
+@article{dehghani2009near,
+  title={Near infrared optical tomography using NIRFAST: Algorithm for numerical model and image reconstruction},
+  author={Dehghani, Hamid and Eames, Matthew E and Yalavarthy, Phaneendra K and Davis, Scott C and Srinivasan, Subhadra and Carpenter, Colin M and Pogue, Brian W and Paulsen, Keith D},
+  journal={Communications in numerical methods in engineering},
+  volume={25},
+  number={6},
+  pages={711--732},
+  year={2009},
+  publisher={Wiley Online Library}
+}

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -56,3 +56,4 @@ dependencies:
       - snirf==0.8
       - pmcx==0.3.3
       - sphinxcontrib-bibtex
+      - pybind11

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -56,4 +56,4 @@ dependencies:
       - snirf==0.8
       - pmcx==0.3.3
       - sphinxcontrib-bibtex
-      - pybind11
+      

--- a/install_nirfaster.sh
+++ b/install_nirfaster.sh
@@ -28,7 +28,7 @@ ZIP_FILE="nirfaster-uFF-main.zip"
 
 
 # wget -qO- "$ZIP_URL"| tar xvz -C .
-wget -qO- "$ZIP_URL" > temp.zip && unzip temp.zip -d . && rm temp.zip
+curl -sL "$ZIP_URL" -o temp.zip && unzip temp.zip -d . && rm temp.zip
 
 FOLDER_NAME=$(basename "$ZIP_FILE" .zip)
 mv "${FOLDER_NAME}" "${FOLDER_NAME%-main}"
@@ -38,14 +38,15 @@ SOURCE_URL="https://github.com/milabuob/nirfaster-uFF/releases/download/v0.9.6/"
 
 if [ $1 = 'CPU' ]; then
     # wget -qO- "$SOURCE_URL""cpu-"$OS_NAME"-python311.zip"| tar xvz -C "${FOLDER_NAME%-main}""/nirfasteruff/" 
-    wget -qO temp.zip "$SOURCE_URL""cpu-"$OS_NAME"-python311.zip" && unzip temp.zip -d "${FOLDER_NAME%-main}/nirfasteruff/" && rm temp.zip
+    curl -sL "$SOURCE_URL""cpu-"$OS_NAME"-python311.zip" -o temp.zip && unzip temp.zip -d "${FOLDER_NAME%-main}/nirfasteruff/" && rm temp.zip
 
 elif [ $1 = 'GPU' ]; then
     # wget -qO- "$SOURCE_URL""cpu-"$OS_NAME"-python311.zip"| tar xvz -C "${FOLDER_NAME%-main}""/nirfasteruff/";
-    wget -qO temp.zip "$SOURCE_URL""cpu-"$OS_NAME"-python311.zip" && unzip temp.zip -d "${FOLDER_NAME%-main}/nirfasteruff/" && rm temp.zip
+    curl -sL "$SOURCE_URL""cpu-"$OS_NAME"-python311.zip" -o temp.zip && unzip temp.zip -d "${FOLDER_NAME%-main}/nirfasteruff/" && rm temp.zip
 
     # wget -qO- "$SOURCE_URL""gpu-"$OS_NAME"-python311.zip"| tar xvz -C "${FOLDER_NAME%-main}""/nirfasteruff/"
-    wget -qO temp.zip "$SOURCE_URL""gpu-"$OS_NAME"-python311.zip" && unzip temp.zip -d "${FOLDER_NAME%-main}/nirfasteruff/" && rm temp.zip
+    curl -sL "$SOURCE_URL""gpu-"$OS_NAME"-python311.zip" -o temp.zip && unzip temp.zip -d "${FOLDER_NAME%-main}/nirfasteruff/" && rm temp.zip
+
 
 fi
 

--- a/install_nirfaster.sh
+++ b/install_nirfaster.sh
@@ -14,12 +14,12 @@ esac
 
 echo "Operating System Detected: $OS_NAME"
 if [ "$OS_NAME" = "Unknown" ]; then
-    echo "Error: Failed at detecting the operating system. Plaese visit the NIRFASTer documentation and install it on your system: https://github.com/milabuob/nirfaster-uFF"
+    echo "Error: Failed at detecting the operating system. Plaese visit the NIRFASTer documentation and install it on your system: https://github.com/milabuob/nirfaster-uFF";
     exit 1
 fi
 
 if [ "$OS_NAME" = "mac" -a $1 = 'GPU' ]; then
-    echo "Error: No releases are available for your configuration. please visit: https://github.com/milabuob/nirfaster-uFF"
+    echo "Error: No releases are available for your configuration. please visit: https://github.com/milabuob/nirfaster-uFF";
     exit 1
 fi
 
@@ -27,7 +27,8 @@ ZIP_URL="https://github.com/milabuob/nirfaster-uFF/archive/refs/heads/main.zip"
 ZIP_FILE="nirfaster-uFF-main.zip"
 
 
-wget -qO- "$ZIP_URL"| tar xvz -C .
+# wget -qO- "$ZIP_URL"| tar xvz -C .
+wget -qO- "$ZIP_URL" > temp.zip && unzip temp.zip -d . && rm temp.zip
 
 FOLDER_NAME=$(basename "$ZIP_FILE" .zip)
 mv "${FOLDER_NAME}" "${FOLDER_NAME%-main}"
@@ -36,10 +37,16 @@ mv "${FOLDER_NAME}" "${FOLDER_NAME%-main}"
 SOURCE_URL="https://github.com/milabuob/nirfaster-uFF/releases/download/v0.9.6/"
 
 if [ $1 = 'CPU' ]; then
-    wget -qO- "$SOURCE_URL""cpu-"$OS_NAME"-python311.zip"| tar xvz -C "${FOLDER_NAME%-main}""/nirfasteruff/" 
+    # wget -qO- "$SOURCE_URL""cpu-"$OS_NAME"-python311.zip"| tar xvz -C "${FOLDER_NAME%-main}""/nirfasteruff/" 
+    wget -qO temp.zip "$SOURCE_URL""cpu-"$OS_NAME"-python311.zip" && unzip temp.zip -d "${FOLDER_NAME%-main}/nirfasteruff/" && rm temp.zip
+
 elif [ $1 = 'GPU' ]; then
-    wget -qO- "$SOURCE_URL""cpu-"$OS_NAME"-python311.zip"| tar xvz -C "${FOLDER_NAME%-main}""/nirfasteruff/"
-    wget -qO- "$SOURCE_URL""gpu-"$OS_NAME"-python311.zip"| tar xvz -C "${FOLDER_NAME%-main}""/nirfasteruff/"
+    # wget -qO- "$SOURCE_URL""cpu-"$OS_NAME"-python311.zip"| tar xvz -C "${FOLDER_NAME%-main}""/nirfasteruff/";
+    wget -qO temp.zip "$SOURCE_URL""cpu-"$OS_NAME"-python311.zip" && unzip temp.zip -d "${FOLDER_NAME%-main}/nirfasteruff/" && rm temp.zip
+
+    # wget -qO- "$SOURCE_URL""gpu-"$OS_NAME"-python311.zip"| tar xvz -C "${FOLDER_NAME%-main}""/nirfasteruff/"
+    wget -qO temp.zip "$SOURCE_URL""gpu-"$OS_NAME"-python311.zip" && unzip temp.zip -d "${FOLDER_NAME%-main}/nirfasteruff/" && rm temp.zip
+
 fi
 
 if [ "$OS_NAME" = 'mac' ]; then

--- a/install_nirfaster.sh
+++ b/install_nirfaster.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Download and install NIRFASTer
+
+echo "Installing NIRFASTer..."
+
+OS="$(uname -s)"
+
+case "$OS" in
+    Linux*)     OS_NAME="linux";;
+    Darwin*)    OS_NAME="mac";;
+    CYGWIN*|MINGW*|MSYS*) OS_NAME="win";;
+    *)          OS_NAME="Unknown";;
+esac
+
+echo "Operating System Detected: $OS_NAME"
+if [ "$OS_NAME" = "Unknown" ]; then
+    echo "Error: Failed at detecting the operating system. Plaese visit the NIRFASTer documentation and install it on your system: https://github.com/milabuob/nirfaster-uFF"
+    exit 1
+fi
+
+if [ "$OS_NAME" = "mac" -a $1 = 'GPU' ]; then
+    echo "Error: No releases are available for your configuration. please visit: https://github.com/milabuob/nirfaster-uFF"
+    exit 1
+fi
+
+ZIP_URL="https://github.com/milabuob/nirfaster-uFF/archive/refs/heads/main.zip" 
+ZIP_FILE="nirfaster-uFF-main.zip"
+
+
+wget -qO- "$ZIP_URL"| tar xvz -C .
+
+FOLDER_NAME=$(basename "$ZIP_FILE" .zip)
+mv "${FOLDER_NAME}" "${FOLDER_NAME%-main}"
+
+
+SOURCE_URL="https://github.com/milabuob/nirfaster-uFF/releases/download/v0.9.6/"
+
+if [ $1 = 'CPU' ]; then
+    wget -qO- "$SOURCE_URL""cpu-"$OS_NAME"-python311.zip"| tar xvz -C "${FOLDER_NAME%-main}""/nirfasteruff/" 
+elif [ $1 = 'GPU' ]; then
+    wget -qO- "$SOURCE_URL""cpu-"$OS_NAME"-python311.zip"| tar xvz -C "${FOLDER_NAME%-main}""/nirfasteruff/"
+    wget -qO- "$SOURCE_URL""gpu-"$OS_NAME"-python311.zip"| tar xvz -C "${FOLDER_NAME%-main}""/nirfasteruff/"
+fi
+
+if [ "$OS_NAME" = 'mac' ]; then
+    xattr -c "${FOLDER_NAME%-main}/nirfasteruff/nirfasteruff_cpu.cpython-311-darwin.so"
+fi
+
+echo "NIRFASTer installed successfully."

--- a/install_nirfaster.sh
+++ b/install_nirfaster.sh
@@ -23,11 +23,21 @@ if [ "$OS_NAME" = "mac" -a $1 = 'GPU' ]; then
     exit 1
 fi
 
+# Define the directory name
+DIR_NAME="plugins"
+
+# Check if the directory exists
+if [ ! -d "$DIR_NAME" ]; then
+  # If the directory does not exist, create it
+  mkdir -p "$DIR_NAME"
+fi
+
+cd "$DIR_NAME"
+
 ZIP_URL="https://github.com/milabuob/nirfaster-uFF/archive/refs/heads/main.zip" 
 ZIP_FILE="nirfaster-uFF-main.zip"
 
 
-# wget -qO- "$ZIP_URL"| tar xvz -C .
 curl -sL "$ZIP_URL" -o temp.zip && unzip temp.zip -d . && rm temp.zip
 
 FOLDER_NAME=$(basename "$ZIP_FILE" .zip)
@@ -37,14 +47,10 @@ mv "${FOLDER_NAME}" "${FOLDER_NAME%-main}"
 SOURCE_URL="https://github.com/milabuob/nirfaster-uFF/releases/download/v0.9.6/"
 
 if [ $1 = 'CPU' ]; then
-    # wget -qO- "$SOURCE_URL""cpu-"$OS_NAME"-python311.zip"| tar xvz -C "${FOLDER_NAME%-main}""/nirfasteruff/" 
     curl -sL "$SOURCE_URL""cpu-"$OS_NAME"-python311.zip" -o temp.zip && unzip temp.zip -d "${FOLDER_NAME%-main}/nirfasteruff/" && rm temp.zip
 
 elif [ $1 = 'GPU' ]; then
-    # wget -qO- "$SOURCE_URL""cpu-"$OS_NAME"-python311.zip"| tar xvz -C "${FOLDER_NAME%-main}""/nirfasteruff/";
     curl -sL "$SOURCE_URL""cpu-"$OS_NAME"-python311.zip" -o temp.zip && unzip temp.zip -d "${FOLDER_NAME%-main}/nirfasteruff/" && rm temp.zip
-
-    # wget -qO- "$SOURCE_URL""gpu-"$OS_NAME"-python311.zip"| tar xvz -C "${FOLDER_NAME%-main}""/nirfasteruff/"
     curl -sL "$SOURCE_URL""gpu-"$OS_NAME"-python311.zip" -o temp.zip && unzip temp.zip -d "${FOLDER_NAME%-main}/nirfasteruff/" && rm temp.zip
 
 

--- a/src/cedalion/imagereco/forward_model.py
+++ b/src/cedalion/imagereco/forward_model.py
@@ -550,6 +550,19 @@ class ForwardModel:
         -------
         xr.DataArray
             Fluence in each voxel for each channel and wavelength.
+
+        References:
+            (:cite:t:`fang2009monte`) Qianqian Fang and David A. Boas, "Monte Carlo Simulation of Photon Migration in
+            3D Turbid Media Accelerated by Graphics Processing Units," Optics Express, 
+            vol. 17, issue 22, pp. 20178-20190 (2009).
+            (:cite:t:`yu2018scalable`) Leiming Yu, Fanny Nina-Paravecino, David Kaeli, Qianqian Fang, “Scalable and 
+            massively parallel Monte Carlo photon transport simulations for heterogeneous 
+            computing platforms,” J. Biomed. Opt. 23(1), 010504 (2018).
+            (:cite:t:`yan2020hybrid`) Shijie Yan and Qianqian Fang* (2020), "Hybrid mesh and voxel based Monte Carlo 
+            algorithm for accurate and efficient photon transport modeling in complex bio-tissues," 
+            Biomed. Opt. Express, 11(11) pp. 6262-6270. 
+            https://www.osapublishing.org/boe/abstract.cfm?uri=boe-11-11-6262
+
         """
 
         wavelengths = self.measurement_list.wavelength.unique()
@@ -628,6 +641,10 @@ class ForwardModel:
         -------
         xr.DataArray
             Fluence in each voxel for each channel and wavelength.
+
+        References:
+            (:cite:t:`dehghani2009near`) Dehghani, Hamid, et al. "Near infrared optical tomography using NIRFAST: Algorithm for numerical model 
+            and image reconstruction." Communications in numerical methods in engineering 25.6 (2009): 711-732.
         """
         if meshingparam == None:
             # meshing parameters; should be adjusted depending on the user's need

--- a/src/cedalion/imagereco/forward_model.py
+++ b/src/cedalion/imagereco/forward_model.py
@@ -20,7 +20,7 @@ from cedalion.imagereco.utils import map_segmentation_mask_to_surface
 
 from .tissue_properties import get_tissue_properties
 
-src_path = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../../nirfaster-uFF'))
+src_path = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../../plugins/nirfaster-uFF'))
 if src_path not in sys.path:
     sys.path.append(src_path)
 

--- a/src/cedalion/imagereco/forward_model.py
+++ b/src/cedalion/imagereco/forward_model.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 import logging
 from typing import Optional
 import os.path
+import sys
 
 import numpy as np
 import pandas as pd
@@ -18,6 +19,12 @@ from cedalion.geometry.segmentation import surface_from_segmentation
 from cedalion.imagereco.utils import map_segmentation_mask_to_surface
 
 from .tissue_properties import get_tissue_properties
+
+src_path = os.path.abspath('../nirfaster-uFF')
+if src_path not in sys.path:
+    sys.path.append(src_path)
+
+import nirfasteruff as ff
 
 logger = logging.getLogger("cedalion")
 
@@ -531,8 +538,8 @@ class ForwardModel:
 
         return result
 
-    def compute_fluence(self, nphoton: int = 1e8):
-        """Compute fluence for each channel and wavelength from photon simulation.
+    def compute_fluence_mcx(self, nphoton: int = 1e8):
+        """Compute fluence for each channel and wavelength from photon simulation using MCX package.
 
         Parameters
         ----------
@@ -598,6 +605,104 @@ class ForwardModel:
             },
         )
 
+        return fluence_all, fluence_at_optodes
+
+
+    def compute_fluence_nirfaster(
+            self, meshingparam : ff.utils.MeshingParams = None, 
+            solver : str = ff.utils.get_solver(), 
+            solver_opt : ff.utils.SolverOptions =ff.utils.SolverOptions()
+            ):
+        """Compute fluence for each channel and wavelength from photon simulation using NIRFASTer package.
+
+        Parameters
+        ----------
+        meshingparam : ff.utils.MeshingParam
+            Parameters to be used by the CGAL mesher. Note: they should all be double
+        solver : 
+            Choose between 'CPU' or 'GPU' solver (case insensitive). Automatically determined (GPU prioritized) if not specified
+        solver_opt :
+            Contains the parameters used by the FEM solvers, Equivalent to 'solver_options' in the Matlab version
+        
+        Returns
+        -------
+        xr.DataArray
+            Fluence in each voxel for each channel and wavelength.
+        """
+        if meshingparam == None:
+            # meshing parameters; should be adjusted depending on the user's need
+            meshingparam = ff.utils.MeshingParams(facet_distance=1., facet_size=1., general_cell_size=2., lloyd_smooth=0)
+            
+        # create a nirfaster mesh
+        mesh = ff.base.stndmesh()
+        # make the optical property matrix; unit in mm-1
+        tissueprop = np.zeros((self.tissue_properties.shape[0]-1, 4))
+        for i in range(tissueprop.shape[0]):
+            tissueprop[i,0] = i+1
+            tissueprop[i,1] = self.tissue_properties[i+1, 0]
+            tissueprop[i,2] = self.tissue_properties[i+1, 1] * (1-self.tissue_properties[i+1, 2])
+            tissueprop[i,3] = self.tissue_properties[i+1, 3]
+            
+        # all optodes x all optodes
+        sources = ff.base.optode(coord=self.optode_pos.data)
+        detectors = ff.base.optode(coord=self.optode_pos.data)
+        n_optodes = self.optode_pos.data.shape[0]
+        link = np.zeros((n_optodes*n_optodes,3), dtype=np.int32)
+        ch = 0
+        for i in range(n_optodes):
+            for j in range(n_optodes):
+                link[ch, 0] = i+1
+                link[ch, 1] = j+1
+                link[ch, 2] = 1
+                ch += 1
+                
+        # construct the mesh
+        mesh.from_volume(self.volume, param=meshingparam, prop=tissueprop, src=sources, det=detectors, link = link)
+        # calculate the interpolation functions to and from voxel space
+        igrid = np.arange(self.volume.shape[0])
+        jgrid = np.arange(self.volume.shape[1])
+        kgrid = np.arange(self.volume.shape[2])
+        mesh.gen_intmat(igrid, jgrid, kgrid)
+        # calculate fluence
+        data,_ = mesh.femdata(0, solver=solver, opt=solver_opt)
+        amplitude_optode = np.reshape(data.amplitude, (n_optodes,-1))
+
+        wavelengths = self.measurement_list.wavelength.unique()
+        n_wavelength = len(wavelengths)
+        fluence_all = np.zeros((n_optodes, n_wavelength) + self.volume.shape)
+        fluence_at_optodes = np.zeros((n_optodes, n_optodes, n_wavelength))
+
+        for i_wl in range(n_wavelength):
+            # PLACEHOLDER: set new property and repeat
+            # This way we can void the expensive meshing
+            # newprop = []
+            # mesh.set_prop(newprop)
+            # newdata,_=femdata(0)
+            for i_opt in range(n_optodes):
+                fluence_all[i_opt,i_wl,:,:,:] = np.transpose(data.phi[:,:,:,i_opt], (1,0,2)) # xyz to ijk
+                fluence_at_optodes[i_opt, :, i_wl] = amplitude_optode[:,i_opt]
+
+        # convert to DataArray; copied from foward_model
+        fluence_all = xr.DataArray(
+            fluence_all,
+            dims=["label", "wavelength", "i", "j", "k"],
+            coords={
+                "label": ("label", self.optode_pos.label.values),
+                "type": ("label", self.optode_pos.type.values),
+                "wavelength": ("wavelength", wavelengths),
+            },
+        )
+
+        fluence_at_optodes = xr.DataArray(
+            fluence_at_optodes,
+            dims=["optode1", "optode2", "wavelength"],
+            coords={
+                "optode1": self.optode_pos.label.values,
+                "optode2": self.optode_pos.label.values,
+                "wavelength": wavelengths,
+            },
+        )
+        
         return fluence_all, fluence_at_optodes
 
 

--- a/src/cedalion/imagereco/forward_model.py
+++ b/src/cedalion/imagereco/forward_model.py
@@ -20,7 +20,7 @@ from cedalion.imagereco.utils import map_segmentation_mask_to_surface
 
 from .tissue_properties import get_tissue_properties
 
-src_path = os.path.abspath('../nirfaster-uFF')
+src_path = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../../nirfaster-uFF'))
 if src_path not in sys.path:
     sys.path.append(src_path)
 

--- a/src/cedalion/imagereco/forward_model.py
+++ b/src/cedalion/imagereco/forward_model.py
@@ -20,12 +20,6 @@ from cedalion.imagereco.utils import map_segmentation_mask_to_surface
 
 from .tissue_properties import get_tissue_properties
 
-src_path = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../../plugins/nirfaster-uFF'))
-if src_path not in sys.path:
-    sys.path.append(src_path)
-
-import nirfasteruff as ff
-
 logger = logging.getLogger("cedalion")
 
 
@@ -622,9 +616,7 @@ class ForwardModel:
 
 
     def compute_fluence_nirfaster(
-            self, meshingparam : ff.utils.MeshingParams = None, 
-            solver : str = ff.utils.get_solver(), 
-            solver_opt : ff.utils.SolverOptions =ff.utils.SolverOptions()
+            self, meshingparam = None
             ):
         """Compute fluence for each channel and wavelength from photon simulation using NIRFASTer package.
 
@@ -632,11 +624,7 @@ class ForwardModel:
         ----------
         meshingparam : ff.utils.MeshingParam
             Parameters to be used by the CGAL mesher. Note: they should all be double
-        solver : 
-            Choose between 'CPU' or 'GPU' solver (case insensitive). Automatically determined (GPU prioritized) if not specified
-        solver_opt :
-            Contains the parameters used by the FEM solvers, Equivalent to 'solver_options' in the Matlab version
-        
+       
         Returns
         -------
         xr.DataArray
@@ -646,6 +634,18 @@ class ForwardModel:
             (:cite:t:`dehghani2009near`) Dehghani, Hamid, et al. "Near infrared optical tomography using NIRFAST: Algorithm for numerical model 
             and image reconstruction." Communications in numerical methods in engineering 25.6 (2009): 711-732.
         """
+
+        src_path = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../../plugins/nirfaster-uFF'))
+        if src_path not in sys.path:
+            sys.path.append(src_path)
+
+        import nirfasteruff as ff
+
+        # Choose between 'CPU' or 'GPU' solver (case insensitive). Automatically determined (GPU prioritized) if not specified
+        solver = ff.utils.get_solver()
+        # Contains the parameters used by the FEM solvers, Equivalent to 'solver_options' in the Matlab version
+        solver_opt = ff.utils.SolverOptions()
+
         if meshingparam == None:
             # meshing parameters; should be adjusted depending on the user's need
             meshingparam = ff.utils.MeshingParams(facet_distance=1., facet_size=1., general_cell_size=2., lloyd_smooth=0)


### PR DESCRIPTION
This pull request introduces the following changes:

1. Simulation Options: Added the option to use either NIRFASTer or MCX for simulating light propagation.
2. NIRFASTer Installation: Included a shell script to simplify the installation process for NIRFASTer. 
3. Documentation Enhancements: Added docstrings to the relevant functions. Updated the references.bib file to include relevant references for both MCX and NIRFASTer.