### PR TITLE
Docstrings for first three notebooks

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -107,3 +107,12 @@ keywords = {Electrode placement, High resolution EEG, High resolution ERP, Nomen
 abstract = {Objective: A system for electrode placement is described. It is designed for studies on topography and source analysis of spontaneous and evoked EEG activity. Method: The proposed system is based on the extended International 10–20 system which contains 74 electrodes, and extends this system up to 345 electrode locations. Results: The positioning and nomenclature of the electrode system is described, and a subset of locations is proposed as especially useful for modern EEG/ERP systems, often having 128 channels available. Conclusion: Similar to the extension of the 10–20 system to the 10–10 system (‘10% system’), proposed in 1985, the goal of this new extension to a 10–5 system is to further promote standardization in high-resolution EEG studies.}
 }
 
+@software{Luke_fNIRS_Finger_Tapping_2021,
+author = {Luke, Robert and McAlpine, David},
+doi = {10.5281/zenodo.5529797},
+month = sep,
+title = {{fNIRS Finger Tapping Data in BIDS Format}},
+version = {v0.0.1},
+year = {2021},
+url = {https://github.com/rob-luke/BIDS-NIRS-Tapping}
+}

--- a/src/cedalion/dataclasses/accessors.py
+++ b/src/cedalion/dataclasses/accessors.py
@@ -12,23 +12,44 @@ from numpy.typing import ArrayLike
 
 @xr.register_dataarray_accessor("cd")
 class CedalionAccessor:
+    """Accessor for time series data stored in xarray DataArrays."""
     def __init__(self, xarray_obj):
-        """TBD."""
+        """Initialize the CedalionAccessor.
+
+        Args:
+            xarray_obj (xr.DataArray): The DataArray to which this accessor is attached.
+        """
         self._validate(xarray_obj)
         self._obj = xarray_obj
 
     @staticmethod
     def _validate(obj):
-        # verify there is a column latitude and a column longitude
+        """Make sure the DataArray has the required dimensions and coordinates."""
 
         if not (("time" in obj.dims) and ("time" in obj.coords)):
             raise AttributeError("Missing time dimension.")
 
     @property
     def sampling_rate(self):
+        """Return the sampling rate of the time series.
+
+        The sampling rate is calculated as the reciprocal of the mean time difference
+            between consecutive samples.
+        """
         return 1 / np.diff(self._obj.time).mean()
 
     def to_epochs(self, df_stim, trial_types, before, after):
+        """Extract epochs from the time series based on stimulus events.
+
+        Args:
+            df_stim (pandas.DataFrame): DataFrame containing stimulus events.
+            trial_types (list): List of trial types to include in the epochs.
+            before (float): Time in seconds before stimulus event to include in epoch.
+            after (float): Time in seconds after stimulus event to include in epoch.
+
+        Returns:
+            xarray.DataArray: Array containing the extracted epochs.
+        """
         # FIXME before units
         # FIXME error handling of boundaries
         tmp = df_stim[df_stim.trial_type.isin(trial_types)]
@@ -66,7 +87,16 @@ class CedalionAccessor:
         return epochs
 
     def freq_filter(self, fmin, fmax, butter_order=4):
-        """Apply a Butterworth frequency filter."""
+        """Applys a Butterworth filter.
+
+        Args:
+            fmin (float): The lower cutoff frequency.
+            fmax (float): The upper cutoff frequency.
+            butter_order (int): The order of the Butterworth filter.
+
+        Returns:
+            result (xarray.DataArray): The filtered time series.
+        """
         array = self._obj
 
         fny = array.cd.sampling_rate / 2
@@ -240,13 +270,20 @@ class PointsAccessor:
 
 @pd.api.extensions.register_dataframe_accessor("cd")
 class StimAccessor:
+    """Accessor for stimulus DataFrames."""
     def __init__(self, pandas_obj):
-        """TBD."""
+        """Initialize the StimAccessor.
+
+        Args:
+            pandas_obj (pd.DataFrame): The pandas DataFrame to which this accessor is
+                attached.
+        """
         self._validate(pandas_obj)
         self._obj = pandas_obj
 
     @staticmethod
     def _validate(obj):
+        """Make sure the DataFrame has the required columns for stimulus data."""
         for column_name in ["onset", "duration", "value", "trial_type"]:
             if column_name not in obj.columns:
                 raise AttributeError(
@@ -254,6 +291,12 @@ class StimAccessor:
                 )
 
     def rename_events(self, rename_dict):
+        """Renames trial types in the DataFrame based on the provided dictionary.
+
+        Args:
+            rename_dict (dict): A dictionary with the old trial type as key and the new
+                trial type as value.
+        """
         stim = self._obj
         for old_trial_type, new_trial_type in rename_dict.items():
             stim.loc[stim.trial_type == old_trial_type, "trial_type"] = new_trial_type

--- a/src/cedalion/datasets.py
+++ b/src/cedalion/datasets.py
@@ -1,4 +1,4 @@
-"""Cedalin datasets and utility functions."""
+"""Cedalion datasets and utility functions."""
 
 import os.path
 import pickle
@@ -67,7 +67,7 @@ def get_colin27_headmodel():
 def get_fingertapping() -> cdc.Recording:
     """Retrieves a finger tapping recording in BIDS format.
 
-    Data is provided by Robe Luke and is also available at https://github.com/rob-luke/BIDS-NIRS-Tapping
+    Data is from :cite:t:`Luke_fNIRS_Finger_Tapping_2021`
     """
     fnames = DATASETS.fetch("fingertapping.zip", processor=pooch.Unzip())
 

--- a/src/cedalion/datasets.py
+++ b/src/cedalion/datasets.py
@@ -65,6 +65,10 @@ def get_colin27_headmodel():
 
 
 def get_fingertapping() -> cdc.Recording:
+    """Retrieves a finger tapping recording in BIDS format.
+
+    Data is provided by Robe Luke and is also available at https://github.com/rob-luke/BIDS-NIRS-Tapping
+    """
     fnames = DATASETS.fetch("fingertapping.zip", processor=pooch.Unzip())
 
     fname = [i for i in fnames if i.endswith(".snirf")][0]

--- a/src/cedalion/io/snirf.py
+++ b/src/cedalion/io/snirf.py
@@ -178,6 +178,15 @@ def reduce_ndim_sourceLabels(sourceLabels: np.ndarray) -> list:
 
 
 def labels_and_positions(probe):
+    """Extract 3D coordinates of optodes and landmarks from a nirs probe variable.
+
+    Args:
+        probe: Nirs probe geometry variable, see snirf documentation.
+
+    Returns:
+        Tuple(np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray):
+            Tuple containing the source, detector and landmark labels/positions.
+    """
     def convert_none(probe, attrname, default):
         attr = getattr(probe, attrname)
         if attr is None:
@@ -220,6 +229,17 @@ def labels_and_positions(probe):
 
 
 def geometry_from_probe(nirs_element: NirsElement):
+    """Extract 3D coordinates of optodes and landmarks from the nirs element probe information.
+
+    Args:
+        nirs_element (NirsElement): Nirs data element as specified in the snirf
+            documentation.
+
+    Returns:
+        result (xr.DataArray, (label, pos)): A DataArray containing the 3D coordinates
+            of optodes and landmarks, with dimensions 'label' and
+            'pos' and coordinates 'label' and 'type'.
+    """
     probe = nirs_element.probe
 
     length_unit = nirs_element.metaDataTags.LengthUnit
@@ -262,6 +282,16 @@ def geometry_from_probe(nirs_element: NirsElement):
 def measurement_list_to_dataframe(
     measurement_list: MeasurementList, drop_none: bool = False
 ):
+    """Converts a snirf MeasurementList object to a pandas DataFrame.
+
+    Args:
+        measurement_list (MeasurementList): MeasurementList object as specified in the snirf
+            documentation.
+        drop_none (bool): If True, drop columns that are None for all rows.
+
+    Returns:
+        pd.DataFrame: DataFrame containing the measurement list information.
+    """
     fields = [
         "sourceIndex",
         "detectorIndex",
@@ -288,6 +318,15 @@ def measurement_list_to_dataframe(
 
 
 def meta_data_tags_to_dict(nirs_element: NirsElement) -> OrderedDict[str, Any]:
+    """Converts the metaDataTags of a nirs element to a dictionary.
+
+    Args:
+        nirs_element (NirsElement): Nirs data element as specified in the snirf
+            documentation.
+
+    Returns:
+        OrderedDict[str, Any]: Dictionary containing the metaDataTags information.
+    """
     mdt = nirs_element.metaDataTags
 
     fields = mdt._snirf_names + mdt._unspecified_names
@@ -296,6 +335,14 @@ def meta_data_tags_to_dict(nirs_element: NirsElement) -> OrderedDict[str, Any]:
 
 
 def stim_to_dataframe(stim: Stim):
+    """Converts a snirf Stim object to a pandas DataFrame.
+
+    Args:
+        stim (Stim): Stim object as specified in the snirf documentation.
+
+    Returns:
+        pd.DataFrame: DataFrame containing the stimulus information.
+    """
     dfs = []
 
     if len(stim) == 0:
@@ -326,6 +373,19 @@ def stim_to_dataframe(stim: Stim):
 def read_aux(
     nirs_element: NirsElement, opts: dict[str, Any]
 ) -> OrderedDict[str, xr.DataArray]:
+    """Reads the aux data from a nirs element into a dictionary of DataArrays.
+
+    Args:
+        nirs_element (NirsElement): Nirs data element as specified in the snirf
+            documentation.
+        opts (dict[str, Any]): Options for reading the aux data. The following
+            options are supported:
+            - squeeze_aux (bool): If True, squeeze the aux data to remove
+                dimensions of size 1.
+
+    Returns:
+        result (OrderedDict[str, xr.DataArray]): Dictionary containing the aux data
+    """
     result = OrderedDict()
 
     # units that need to be converted to pint units
@@ -389,7 +449,18 @@ def read_aux(
 
 
 def add_number_to_name(name, keys):
-    """Changes name to name_<number>."""
+    """Changes name to name_<number>.
+
+    Number appended to name is the smallest number that makes the new name unique with
+    respect to the list of keys.
+
+    Args:
+        name (str): Name to which a number should be added.
+        keys (list[str]): List of keys to which the new name should be compared.
+
+    Returns:
+        str: New name with number added.
+    """
 
     pat = re.compile(rf"{name}(_(\d+))?")
     max_number = 1
@@ -405,6 +476,18 @@ def add_number_to_name(name, keys):
 def read_data_elements(
     data_element: DataElement, nirs_element: NirsElement, stim: pd.DataFrame
 ) -> list[tuple[str, NDTimeSeries]]:
+    """Reads the data elements from a nirs element into a list of DataArrays.
+
+    Args:
+        data_element (DataElement): Data element as specified in the snirf documentation.
+        nirs_element (NirsElement): Nirs data element as specified in the snirf
+            documentation.
+        stim (pd.DataFrame): DataFrame containing the stimulus information.
+
+    Returns:
+        list[tuple[str, NDTimeSeries]]: List of tuples containing the canonical name
+            of the data element and the DataArray.
+    """
     time = data_element.time
 
     trial_types = stim["trial_type"].drop_duplicates().values
@@ -585,6 +668,19 @@ def _get_channel_coords(
 
 
 def read_nirs_element(nirs_element, opts):
+    """Reads a single nirs element from a .snirf file into a Recording object.
+
+    Args:
+        nirs_element (NirsElement): Nirs data element as specified in the snirf
+            documentation
+        opts (dict[str, Any]): Options for reading the data element. The following
+            options are supported:
+            - squeeze_aux (bool): If True, squeeze the aux data to remove
+                dimensions of size 1.
+
+    Returns:
+        rec (Recording): Recording object containing the data from the nirs element.
+    """
     geo3d = geometry_from_probe(nirs_element)
     stim = stim_to_dataframe(nirs_element.stim)
 
@@ -635,6 +731,17 @@ def read_nirs_element(nirs_element, opts):
 
 
 def read_snirf(fname: Path | str, squeeze_aux=False) -> list[cdc.Recording]:
+    """Reads a .snirf file into a list of Recording objects.
+
+    Args:
+        fname (Path | str): Path to .snirf file
+        squeeze_aux (Bool): If True, squeeze the aux data to remove
+            dimensions of size 1.
+
+    Returns:
+        list[Recording]: List of Recording objects containing the data from the nirs
+        elements in the .snirf file.
+    """
     opts = {"squeeze_aux": squeeze_aux}
 
     if isinstance(fname, Path):
@@ -645,6 +752,18 @@ def read_snirf(fname: Path | str, squeeze_aux=False) -> list[cdc.Recording]:
 
 
 def denormalize_measurement_list(df_ml: pd.DataFrame, nirs_element: NirsElement):
+    """Enriches measurement list DataFrame with additional information.
+
+    Args:
+        df_ml (pd.DataFrame): DataFrame containing the measurement list information.
+        nirs_element (NirsElement): Nirs data element as specified in the snirf
+            documentation.
+
+    Returns:
+        pd.DataFrame: DataFrame containing the measurement list information with
+            additional columns for channel, source, detector, wavelength and chromo.
+
+    """
     sourceLabels, detectorLabels, landmarkLabels, _, _, _ = labels_and_positions(
         nirs_element.probe
     )

--- a/src/cedalion/nirs.py
+++ b/src/cedalion/nirs.py
@@ -125,8 +125,8 @@ def od2conc(
             coefficients. Defaults to "prahl".
 
     Returns:
-        conc (xr.DataArray, (channel, wavelength, *)): A data array containing
-            concentration changes with dimensions "channel" and "wavelength".
+        conc (xr.DataArray, (channel, *)): A data array containing
+            concentration changes by channel.
     """
     validators.has_channel(od)
     validators.has_wavelengths(od)
@@ -165,7 +165,7 @@ def beer_lambert(
             coefficients. Defaults to "prahl".
 
     Returns:
-        conc (xr.DataArray, (channel, wavelength, *)): A data array containing
+        conc (xr.DataArray, (channel, *)): A data array containing
             concentration changes according to the mBLL.
     """
     validators.has_channel(amplitudes)

--- a/src/cedalion/xrutils.py
+++ b/src/cedalion/xrutils.py
@@ -9,6 +9,12 @@ def pinv(array: xr.DataArray) -> xr.DataArray:
 
     FIXME: handles unitless and quantified DataArrays but not
            DataArrays with units in their attrs.
+
+    Args:
+        array (xr.DataArray): Input array
+
+    Returns:
+        array_inv (xr.DataArray): Pseudoinverse of the input array
     """
     if not array.ndim == 2:
         raise ValueError("array must have only 2 dimensions")
@@ -42,17 +48,24 @@ def pinv(array: xr.DataArray) -> xr.DataArray:
 
 
 def norm(array: xr.DataArray, dim: str) -> xr.DataArray:
-    """Calculate the vector norm along a given dimension."""
+    """Calculate the vector norm along a given dimension.
+
+    Extends the behavior of numpy.linalg.norm to xarray DataArrays.
+    Args:
+        array (xr.DataArray): Input array
+        dim (str): Dimension along which to calculate the norm
+
+    Returns:
+        normed (xr.DataArray): Array with the norm along the specified dimension
+    """
     if dim not in array.dims:
         raise ValueError(f"array does not have dimension '{dim}'")
-
-    dim_index = array.dims.index(dim)
 
     if (units := array.pint.units) is not None:
         array = array.pint.dequantify()
 
     normed = xr.apply_ufunc(
-        np.linalg.norm, array, input_core_dims=[[dim]], kwargs={"axis": dim_index}
+        np.linalg.norm, array, input_core_dims=[[dim]], kwargs={"axis": -1}
     )
 
     if units is not None:

--- a/src/cedalion/xrutils.py
+++ b/src/cedalion/xrutils.py
@@ -84,20 +84,21 @@ def apply_mask(data_array: xr.DataArray,
                mask: xr.DataArray, operator: str, dim_collapse: str) -> xr.DataArray:
     """Apply a boolean mask to a DataArray according to the defined "operator".
 
-    INPUTS:
-    data_array:     NDTimeSeries, input time series data xarray
-    mask:           input boolean mask array with a subset of dimensions matching data_array
-    operator:       operators to apply to the mask and data_array
-        "nan":          inserts NaNs in the data_array where mask is False
-        "drop":         drops value in the data_array where mask is False
-    dim_collapse:   mask dimension to collapse to, merging boolean masks along all other
-                    dimensions. can be skipped with "none".
-                    Example: collapsing to "channel" dimension will drop or nan a channel
-                    if it is "False" along any other dimensions
+    Args:
+        data_array: NDTimeSeries, input time series data xarray
+        mask: input boolean mask array with a subset of dimensions matching data_array
+        operator: operators to apply to the mask and data_array
+            "nan": inserts NaNs in the data_array where mask is False
+            "drop": drops value in the data_array where mask is False
+        dim_collapse: Mask dimension to collapse to, merging boolean masks along all
+            other dimensions. Can be skipped with "none".
+            Example: collapsing to "channel" dimension will drop or nan a channel if it
+            is "False" along any other dimensions
 
-    OUTPUTS:
-    masked_data_array:    input data_array with applied mask
-    masked_elements:      list of elements in data_array that were masked (e.g. dropped or set to NaN)
+    Returns:
+        masked_data_array: Input data_array with applied mask
+        masked_elements: List of elements in data_array that were masked (e.g. 
+            dropped or set to NaN)
     """
     flag_collapse = False
 

--- a/src/cedalion/xrutils.py
+++ b/src/cedalion/xrutils.py
@@ -97,7 +97,7 @@ def apply_mask(data_array: xr.DataArray,
 
     Returns:
         masked_data_array: Input data_array with applied mask
-        masked_elements: List of elements in data_array that were masked (e.g. 
+        masked_elements: List of elements in data_array that were masked (e.g.
             dropped or set to NaN)
     """
     flag_collapse = False
@@ -122,7 +122,7 @@ def apply_mask(data_array: xr.DataArray,
         masked_data_array = data_array.where(mask, other=np.nan)
     elif operator.lower() == "drop":
         # drops value in the data_array where mask is False.
-        # Note: values are only dropped if mask has "False" across the entire  relevant dimension
+        # Note: values are only dropped if mask has "False" across the entire relevant dimension
         masked_data_array = data_array.where(mask, drop=True)
 
     # return the masked elements if dimensions were collapsed


### PR DESCRIPTION
Added docstrings for functions/classes relevant to the following example notebooks:
- Xarray Data Structures - an fNIRS example
- Channel Quality Assesment, Pruning, and Motion Artifact Detection
- Basic single trial fNIRS finger tapping classification

Also fixed small bug in xrutils.norm



