### PR TITLE
Small bugfix for runing pmcx 

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -170,7 +170,8 @@ abstract={<p>Surface visualizations of fMRI provide a comprehensive view of cort
   year={2009},
   publisher={Wiley Online Library}
 }
-@article{luke2021,
+
+@misc{luke2021,
 author = {Luke, Robert and McAlpine, David},
 doi = {10.5281/zenodo.5529797},
 month = sep,

--- a/src/cedalion/dataclasses/accessors.py
+++ b/src/cedalion/dataclasses/accessors.py
@@ -172,7 +172,9 @@ class PointsAccessor:
 
         assert transform_units is not None
         assert transform.shape == (4, 4)  # FIXME assume 3D
-        assert from_crs in obj.dims
+        assert from_crs in obj.dims, f"Coordinate systems of points " \
+                                     f"({from_crs}) and transform " \
+                                     f"({obj.dims}) do not match."
 
         transform = transform.pint.dequantify()
 

--- a/src/cedalion/imagereco/forward_model.py
+++ b/src/cedalion/imagereco/forward_model.py
@@ -471,7 +471,7 @@ class ForwardModel:
         # Comppute the direction of the light beam from the surface normals
         self.optode_dir = -head_model.scalp.get_vertex_normals(self.optode_pos)
         # Slightly realign the optode positions to the closest scalp voxel
-        self.optode_pos = self.snap_to_scalp_voxels(self.optode_pos)
+        self.optode_pos = head_model.snap_to_scalp_voxels(self.optode_pos)
 
 
         self.optode_pos = self.optode_pos.pint.dequantify()

--- a/src/cedalion/imagereco/forward_model.py
+++ b/src/cedalion/imagereco/forward_model.py
@@ -356,6 +356,61 @@ class TwoSurfaceHeadModel:
         return snapped
 
 
+    # FIXME then maybe this should also not be in this class
+    @cdc.validate_schemas
+    def snap_to_scalp_voxels(
+        self, points: cdt.LabeledPointCloud
+    ) -> cdt.LabeledPointCloud:
+        """Snap optodes or points to the closest scalp voxel.
+
+        Parameters
+        ----------
+        points : cdt.LabeledPointCloud
+            Points to be snapped to the closest scalp voxel.
+
+        Returns
+        -------
+        cdt.LabeledPointCloud
+            Points aligned and snapped to the closest scalp voxel.
+        """
+        # Align to scalp surface
+        aligned = self.scalp.snap(points)
+
+        # Snap to closest scalp voxel
+        snapped = np.zeros(points.shape)
+        for i, a in enumerate(aligned):
+
+            # Get index of scalp surface vertex "a"
+            idx = np.argwhere(self.scalp.mesh.vertices == \
+                              np.array(a.pint.dequantify()))
+
+            # Reduce to indices with repitition of 3 (so all coordinates match)
+            if len(idx) > 3:
+                r = [rep[n] for rep in [{}] for i,n in enumerate(idx[:,0]) \
+                           if rep.setdefault(n,[]).append(i) or len(rep[n])==3]
+                idx = idx[r[0]]
+
+            # Make sure only one vertex is found
+            assert len(idx) == 3
+            assert idx[0,0] == idx[1,0] == idx[2,0]
+
+            # Get voxel indices mapping to this scalp vertex
+            vec = np.zeros(self.scalp.nvertices)
+            vec[idx[0,0]] = 1
+            voxel_idx = np.argwhere(self.voxel_to_vertex_scalp @ vec == 1)[:,0]
+           
+            # Get voxel coordinates from voxel indices
+            shape = self.segmentation_masks.shape[-3:]
+            voxels = np.array(np.unravel_index(voxel_idx, shape)).T
+
+            # Choose the closest voxel
+            dist = np.linalg.norm(voxels - np.array(a.pint.dequantify()), axis=1)
+            snapped[i] = voxels[np.argmin(dist)]
+
+        points.values = snapped
+        return points
+
+
 class ForwardModel:
     """Forward model for simulating light transport in the head.
 
@@ -413,10 +468,11 @@ class ForwardModel:
             geo3d.type.isin([cdc.PointType.SOURCE, cdc.PointType.DETECTOR])
         ]
 
-        #FIXME make sure that optode is in scalp voxel
-        self.optode_pos = self.optode_pos.round()
-
+        # Comppute the direction of the light beam from the surface normals
         self.optode_dir = -head_model.scalp.get_vertex_normals(self.optode_pos)
+        # Slightly realign the optode positions to the closest scalp voxel
+        self.optode_pos = self.snap_to_scalp_voxels(self.optode_pos)
+
 
         self.optode_pos = self.optode_pos.pint.dequantify()
         self.optode_dir = self.optode_dir.pint.dequantify()


### PR DESCRIPTION
Many pmcx simulations currently fail because the optodes are aligned the scalp surface, which is smooth, but its vertices often not inside a scalp voxel (pmcx requirement). This little fix re-aligns the optodes before calling pmcx to their closest scalp voxel.