### PR TITLE
Debug motion correction

### DIFF
--- a/src/cedalion/sigproc/quality.py
+++ b/src/cedalion/sigproc/quality.py
@@ -533,9 +533,11 @@ def id_motion(
 
     # t_motion in samples rounded to the nearest sample
     t_motion_samples = t_motion / fNIRSdata.time.diff(dim="time").mean()
+    t_motion_samples = t_motion_samples.pint.dequantify()
     t_motion_samples = int(t_motion_samples.round())
     # t_mask in samples rounded to the nearest sample
     t_mask_samples = t_mask / fNIRSdata.time.diff(dim="time").mean()
+    t_mask_samples = t_mask_samples.pint.dequantify()
     t_mask_samples = int(t_mask_samples.round())
 
     # calculate the "std_diff", the standard deviation of the approx 1st derivative of


### PR DESCRIPTION
Bug fixes for splineSG and PCArecurse. Changes outlined in the two commits: 
debug splineSG
1. add p parameter to tune the spline interpolation to match homer implementation
2. change how lstMA is defined to match motion mask
3. fix how spline corrected channel data is assigned to clean dataArray (use loc)

debug PCArecurse
1. zscore the input to PCA because principal components were not looking right
2. flip the mask (line 270) to get only noisy time points
3. flip the definition of start and stop of motion segment

4. also dequantified the t_motion_samples and t_mask_samples in id_motion() since this was causing warnings when being cast to an int