### PR TITLE
Minor fix in case of empty segmentation mask 

### DIFF
--- a/src/cedalion/imagereco/tissue_properties.py
+++ b/src/cedalion/imagereco/tissue_properties.py
@@ -89,7 +89,11 @@ def get_tissue_properties(segmentation_masks: xr.DataArray) -> np.ndarray:
 
     for st in segmentation_masks.segmentation_type.values:
         m = segmentation_masks.sel(segmentation_type=st).values
-        int_label = np.unique(m[m > 0]).item()
+        int_labels = np.unique(m[m > 0])
+        if len(int_labels) == 0:
+            print("Warning: %s is empfy." % st)   
+            continue
+        int_label = int_labels.item()
 
         if (tissue_type := TISSUE_LABELS.get(st, None)) is None:
             raise ValueError(f"unknown tissue type '{st}'")


### PR DESCRIPTION
So far creating a head model from segmentation masks failed if any of the masks where empty (this for example in rare cases for air cavities depending on the segmentation routines). With this small code change, the head model can still be created while ignoring the empty mask instead of throwing an error.

