### PR TITLE
Parcel sensitivity mask

### DIFF
--- a/src/cedalion/sigproc/quality.py
+++ b/src/cedalion/sigproc/quality.py
@@ -26,6 +26,25 @@ logger = logging.getLogger("cedalion")
 CLEAN = True
 TAINTED = False
 
+
+def parcel_sensitivity_mask(Adot_brain, parcels, meas_list, chan_mask, sens_thresh):
+    # check if number of channels match everywhere
+    assert len(meas_list) == len(chan_mask) == Adot_brain.shape[0] * Adot_brain.shape[2] # num_chans*wavelengths
+    Adot_brain = np.vstack((Adot_brain[:,:,0], Adot_brain[:,:,1])) # flatten the wavelength dimension
+
+    Adot_brain = Adot_brain[chan_mask, :] # apply the channel mask
+
+    # check if number of brain voxels/vertices match
+    assert len(parcels) == np.sum(Adot_brain)
+
+    # get the parcel names
+    parcel_names = np.unique(parcels) 
+    # for each parcel compure if the summed sensitivity is above the threshold
+    parcel_mask = {roi: np.sum(Adot_brain[:, parcels==roi])>sens_thresh[roi] for roi in parcel_names}
+    
+    return parcel_mask
+
+
 @cdc.validate_schemas
 def prune_ch(
     amplitudes: cdt.NDTimeSeries,

--- a/src/cedalion/sigproc/quality.py
+++ b/src/cedalion/sigproc/quality.py
@@ -27,18 +27,39 @@ CLEAN = True
 TAINTED = False
 
 
-def parcel_sensitivity_mask(Adot_brain, parcels, meas_list, chan_mask, sens_thresh):
-    # check if number of channels match everywhere
-    assert len(meas_list) == len(chan_mask) == Adot_brain.shape[0] * Adot_brain.shape[2] # num_chans*wavelengths
-    Adot_brain = np.vstack((Adot_brain[:,:,0], Adot_brain[:,:,1])) # flatten the wavelength dimension
+def parcel_sensitivity_mask(Adot_brain: xr.DataArray,
+                            parcels: list(str),
+                            chan_mask: list(bool),
+                            sens_thresh: dict(str, float) -> dict(str, bool):
+    """Compute a mask of parcels based on sensitivity values.
 
-    Adot_brain = Adot_brain[chan_mask, :] # apply the channel mask
+    Args:
+        Adot_brain: sensitivity matrix (channels, brain vertices, wavelengths)
+        parcels: parcel label for each brain vertex
+        chan_mask: boolean mask for channels (True if channel is useable,
+                   False if channel has been pruned)
+        sens_thresh: sensitivity threshold for each parcel
+
+    Returns:
+        dict: parcel mask {parcel: bool} (True if sensitivity is above threshold, 
+              False otherwise)
+    """
+
+    # check if number of channels match everywhere
+    assert len(chan_mask) == Adot_brain.shape[0] * Adot_brain.shape[2] # num_chans*wavelengths
+    
+    # flatten the wavelength dimension
+    Adot_brain = np.vstack((Adot_brain[:,:,0], Adot_brain[:,:,1])) 
+
+    # apply the channel mask
+    Adot_brain = Adot_brain[chan_mask, :] 
 
     # check if number of brain voxels/vertices match
     assert len(parcels) == np.sum(Adot_brain)
 
     # get the parcel names
     parcel_names = np.unique(parcels) 
+
     # for each parcel compure if the summed sensitivity is above the threshold
     parcel_mask = {roi: np.sum(Adot_brain[:, parcels==roi])>sens_thresh[roi] for roi in parcel_names}
     


### PR DESCRIPTION
Given the sensitivity matrix, its parcel information and the pruned channels:
Compute which parcels are visible (above the sensitivity threshold).

```
import os, numpy as np, pandas as pd
import cedalion
import cedalion.io as cio
import cedalion.sigproc.quality as cspqu

# load data
DATADIR = os.path.join(<<path_to_datafolder>>)
parcels = np.load(os.path.join(DATADIR, 'parcels.npy'))
Adot_fn = os.path.join(DATADIR, 'Adot.nc')
Adot = cio.load_Adot(Adot_fn)
Adot_brain = Adot[:,Adot.is_brain,:]

# create test input data
num_chans = Adot_brain.shape[0]
chan_quality = np.random.rand(num_chans)
chan_mask = chan_quality > 0.8
sens_thresh = {roi: 0.01 for roi in np.unique(parcels)}

# call function
parcel_mask = cspqu.parcel_sensitivity_mask(Adot_brain, parcels, chan_mask, sens_thresh)
```