### PR TITLE
Minor fix of LandmarksBuilder1010

### DIFF
--- a/src/cedalion/dataclasses/geometry.py
+++ b/src/cedalion/dataclasses/geometry.py
@@ -784,7 +784,7 @@ class PycortexSurface(Surface):
         if d is None:
             d = self.geodesic_distance([b], **kwargs)
         while path[-1] != b:
-            n = np.array([v for v in self.graph.neighbors(path[-1])])
+            n = np.unique((self.mesh.polys[np.where(self.mesh.polys == path[-1])[0], :]))
             path.append(n[d[n].argmin()])
             if len(path) > max_len:
                 return path

--- a/src/cedalion/geometry/landmarks.py
+++ b/src/cedalion/geometry/landmarks.py
@@ -145,6 +145,8 @@ class LandmarksBuilder1010:
 
     def _estimate_cranial_vertex_by_height(self):
         """Find the highest point of the skull."""
+        # FIXME: this only works for coordinate systems with z-axis oriented 
+        # superior like in RAS or ALS coordinate systems!
 
         vertices = vnp.vtk_to_numpy(self.vtk_mesh.GetPoints().GetData())
         highest_vertices = vertices[vertices[:, 2] == vertices[:, 2].max()]
@@ -156,7 +158,7 @@ class LandmarksBuilder1010:
         """Estimate the cranial vertex by intersecting lines through the head."""
         if "Cz" in self.landmarks_mm.label:
             cz1 = self.landmarks_mm.loc["Cz"].values
-            # FIXME remove Cz from landmarks
+            self.landmarks_mm = self.landmarks_mm.drop_sel(label='Cz')
         else:
             cz1 = self._estimate_cranial_vertex_by_height()
 
@@ -226,6 +228,11 @@ class LandmarksBuilder1010:
             attrs={"units": "mm"},
         )
 
+        # Update Cz to match the whole 10-10 system and not stick with the old
+        # (potentially inaccurate) value
+        if 'Cz' in labels:
+            self.landmarks_mm = self.landmarks_mm.drop_sel(label='Cz')
+
         self.landmarks_mm = xr.concat((self.landmarks_mm, tmp), dim="label")
 
         self.lines.append(points)
@@ -237,14 +244,18 @@ class LandmarksBuilder1010:
         cz = self._estimate_cranial_vertex_from_lines()
 
         self.landmarks_mm = self.landmarks_mm.points.add("Cz", cz, PointType.LANDMARK)
+       
+        for _ in range(5): # converge usually after 2-4 iterations
+            self._add_landmarks_along_line(["LPA", "Cz", "RPA"], ["Cz"], [0.5])
+            self._add_landmarks_along_line(["Nz", "Cz", "Iz"], ["Cz"], [0.5])
+
+        self._add_landmarks_along_line(["LPA", "Cz", "RPA"], ["T7", "T8"], [0.1, 0.9])
 
         self._add_landmarks_along_line(
             ["Nz", "Cz", "Iz"],
             ["Fpz", "AFz", "Fz", "FCz", "CPz", "Pz", "POz", "Oz"],
             [0.1, 0.2, 0.3, 0.4, 0.6, 0.7, 0.8, 0.9],
         )
-
-        self._add_landmarks_along_line(["LPA", "Cz", "RPA"], ["T7", "T8"], [0.1, 0.9])
 
         self._add_landmarks_along_line(
             ["Fpz", "T7", "Oz"],


### PR DESCRIPTION
Given we call the LandmarksBuilder1010 with having only RPA, LPA, Nz, Iz landmark (happens quite regularly) - the current algorithm searches for the highest point on the head, defines it as Cz and sticks with it, although it might not be in the middle between the connecting RPA-LPA and Nz-Iz lines (see attached screenshots).

The changes allow to iteratively update Cz by finding its mean position between LPA - RPA and Nz - Iz. Usually, this converges quickly (~2-4 iterations). The final 1010 landmarks are now in themselves consistent and with the changes we also allow for correcting an inaccurate Cz position when additionally providing it as input.

@emiddell, I also tested using [cedalion.dataclasses.PyCortexSurface.geodesic_distance](https://github.com/ibs-lab/cedalion/blob/main/src/cedalion/dataclasses/geometry.py#L645), but the equivalent implementation of iteratively finding/correcting Cz was slower, less robust and generally created more overhead because of additionally using PyCortexSurface next to the existing VTKSurface. I think your current spline-based implementation is still better! (Tested on ~150 heads.)

I also fixed a small bug, that I came across:
[PycortexSurface.geodesic_path calls PycortexSurface.graph](https://github.com/ibs-lab/cedalion/blob/dev/src/cedalion/dataclasses/geometry.py#L787) although it's not an existing attribute.
And a [FIXME](https://github.com/ibs-lab/cedalion/blob/dev/src/cedalion/geometry/landmarks.py#L159).
Therefore I added a new FIXME, that estimating Cz by height will not work for all coordinate systems -> I propose converting to CTF coordinate system first, then estimating Cz by height, and finally transform back into the original coordinate system. Will do this in another PR.

![example_screwed_landmarks](https://github.com/user-attachments/assets/02621ad5-dfb0-4c08-bc5e-8b8307409677)
