### PR TITLE
2SHM from segmentations - fill holes by default

### DIFF
--- a/src/cedalion/imagereco/forward_model.py
+++ b/src/cedalion/imagereco/forward_model.py
@@ -107,7 +107,7 @@ class TwoSurfaceHeadModel:
         smoothing: float = 0.5,
         brain_face_count: Optional[int] = 180000,
         scalp_face_count: Optional[int] = 60000,
-        fill_holes: bool = False,
+        fill_holes: bool = True,
     ) -> "TwoSurfaceHeadModel":
         """Constructor from binary masks as gained from segmented MRI scans.
 


### PR DESCRIPTION
So far, our LandmarksBuilder1010 is failing on cedalion's default heads Colin and ICBM when you construct the TwoSurfaceHeadModel from segmentations:
<img width="471" alt="ScreenshotA" src="https://github.com/user-attachments/assets/9d9ee585-0a31-4091-81f5-0a97006a0f82" />
<img width="530" alt="ScreenshotB" src="https://github.com/user-attachments/assets/50b1137c-f1e6-4c92-8378-17adce50fb6a" />

Problem can be replicated in the [42_1010_system.ipynb](https://github.com/ibs-lab/cedalion/blob/main/examples/head_models/42_1010_system.ipynb) example by replacing 
`head = TwoSurfaceHeadModel.from_surfaces(
    segmentation_dir=SEG_DATADIR,
    mask_files = mask_files,
    brain_surface_file= os.path.join(SEG_DATADIR, "mask_brain.obj"),
    scalp_surface_file= os.path.join(SEG_DATADIR, "mask_scalp.obj"),
    landmarks_ras_file=landmarks_file,
    brain_face_count=None,
    scalp_face_count=None
)`
with
`head = TwoSurfaceHeadModel.from_surfaces(
    segmentation_dir=SEG_DATADIR,
    mask_files = mask_files,
    landmarks_ras_file=landmarks_file,
    brain_face_count=None,
    scalp_face_count=None
)`
i.e. constructing the scalp surface from the segmentation_masks and not using the freesurfer surfaces.

The problem is fixed by setting fill_holes=True.

@eike: We already discussed this during the group meeting today: this should work by default, and we don't see any harm if the fill_holes flag is set to True by default, do you?