### PR TITLE
Update plots.py scalp_plot

### DIFF
--- a/src/cedalion/plots.py
+++ b/src/cedalion/plots.py
@@ -926,7 +926,8 @@ def scalp_plot(
     title: str | None = None,
     vmin: float | None = None,
     vmax: float | None = None,
-    cmap: str = "bwr",
+    cmap: str | matplotlib.colors.Colormap = "bwr",
+    norm: object | None = None,
     bad_color: ColorType = [0.7, 0.7, 0.7],
     min_dist: Quantity | None = None,
     min_metric: float | None = None,
@@ -934,6 +935,8 @@ def scalp_plot(
     optode_size: float = 36.0,
     optode_labels: bool = False,
     cb_label: str | None = None,
+    cb_ticks_labels: list[(float, str)] | None = None,
+    add_colorbar: bool = True,
     zorder : str | None = None,
 ):
     """Creates a 2D plot of the head with channels coloured according to a given metric.
@@ -990,9 +993,12 @@ def scalp_plot(
     if vmax is None:
         vmax = np.nanmax(metric)
 
-    norm = matplotlib.colors.Normalize(vmin=vmin, vmax=vmax)
-    cmap = p.cm.get_cmap(cmap)
-    cmap.set_bad(bad_color)
+    if isinstance(cmap, str):
+        norm = matplotlib.colors.Normalize(vmin=vmin, vmax=vmax)
+        cmap = p.cm.get_cmap(cmap)
+        cmap.set_bad(bad_color)
+    else:
+        cmap.set_bad(bad_color)
 
     ax.set_aspect("equal", adjustable="datalim")
 
@@ -1090,12 +1096,16 @@ def scalp_plot(
     # ax.set_ylim(-1.1, 1.1)
 
     # colorbar
-    cb = p.colorbar(
-        matplotlib.cm.ScalarMappable(cmap=cmap,norm=norm),
-        ax=ax,
-        shrink=0.6
-    )
-    cb.set_label(cb_label)
+    if add_colorbar:
+        cb = p.colorbar(
+            matplotlib.cm.ScalarMappable(cmap=cmap,norm=norm),
+            ax=ax,
+            shrink=0.6
+        )
+        cb.set_label(cb_label)
+        if cb_ticks_labels is not None:
+            cb.set_ticks([tick for tick, _ in cb_ticks_labels])
+            cb.set_ticklabels([label for _, label in cb_ticks_labels])
 
     if title:
         ax.set_title(title)


### PR DESCRIPTION
non breaking change to permit us to define a cmap for scalp_plot. We use this for our prune channels DQR. But it could have broader utility. It should be non-breaking. I tested it.

Here is a code snippet we use to create the prune channels DQR. It does assume you have some data loaded.

`
# Define discrete colors matching the criteria
# Create a discrete colormap and corresponding normalization
colors = ['red', (1,0.9,0.4), (0.5,1,0.5), 'cyan', 'blue', 'magenta']  # Change these colors if needed
bounds = [0.0, 0.19, 0.4, 0.65, 0.8, 0.95, 1]  # Boundaries for categories

cmap = mcolors.ListedColormap(colors)
norm = mcolors.BoundaryNorm(bounds, cmap.N)

# plot
f,axs = p.subplots(1, 1, figsize=(8, 8))

cb_ticks_labels = [(0.1,'Saturated'), (0.3,'Poor SNR'), (0.52,'Good SNR'), (0.72,'SDS'), (0.87,'Low Signal'), (0.975,'SCI/PSP')]
ax1 = axs
plots.scalp_plot( 
        rec[0][0]["amp"],
        rec[0][0].geo3d,
        chs_pruned_subjs[0][0].values, 
        ax1,
        cmap=cmap,#'gist_rainbow',
        norm=norm,
        vmin=0,
        vmax=1,
        optode_labels=True,
        title="",
        optode_size=6,
        cb_ticks_labels = cb_ticks_labels
    )`

It creates this nice image
<img width="502" alt="Screenshot 2025-04-08 at 8 42 06 AM" src="https://github.com/user-attachments/assets/4fd7886e-3ead-479e-a390-0aa6e2caa7bd" />
