### PR TITLE
Adding PointType ELECTRODE & extending load/export_to_tsv

### DIFF
--- a/src/cedalion/dataclasses/geometry.py
+++ b/src/cedalion/dataclasses/geometry.py
@@ -30,6 +30,7 @@ class PointType(Enum):
     SOURCE = 1
     DETECTOR = 2
     LANDMARK = 3
+    ELECTRODE = 4
 
     # provide an ordering of PointTypes so that e.g. np.unique works
     def __lt__(self, other):

--- a/src/cedalion/io/__init__.py
+++ b/src/cedalion/io/__init__.py
@@ -1,5 +1,5 @@
 from .snirf import read_snirf, write_snirf
-from .probe_geometry import read_mrk_json, read_digpts, read_einstar_obj, load_tsv
+from .probe_geometry import read_mrk_json, read_digpts, read_einstar_obj, load_tsv, export_to_tsv
 from .anatomy import read_segmentation_masks
 from .photogrammetry import read_photogrammetry_einstar, read_einstar, opt_fid_to_xr
 from .forward_model import save_Adot, load_Adot

--- a/src/cedalion/io/probe_geometry.py
+++ b/src/cedalion/io/probe_geometry.py
@@ -37,12 +37,13 @@ def load_tsv(tsv_fname: str, crs: str=None, units: str=None) -> xr.DataArray:
         # tsv file contains a header
         data = pd.read_csv(tsv_fname, sep="\t")
     else:
-        data = {'labels': data.iloc[:, 0],
-                'X': data.iloc[:, 1],
-                'Y': data.iloc[:, 2],
-                'Z': data.iloc[:, 3]}
+        datadict = {'labels': data.iloc[:, 0],
+                    'X': data.iloc[:, 1],
+                    'Y': data.iloc[:, 2],
+                    'Z': data.iloc[:, 3]}
         if len(data.columns) > 4:
-            data['PointType'] = data.iloc[:, 4]
+            datadict['PointType'] = data.iloc[:, 4]
+        data = datadict
         
     # parse crs and units
     for k in data.keys():

--- a/src/cedalion/io/probe_geometry.py
+++ b/src/cedalion/io/probe_geometry.py
@@ -5,12 +5,13 @@ import xarray as xr
 import trimesh
 import json
 from collections import OrderedDict
+import pandas as pd
 
 import cedalion
 from cedalion.dataclasses import PointType, TrimeshSurface, build_labeled_points
 
 
-def load_tsv(tsv_fname: str, crs: str='digitized', units: str='mm') -> xr.DataArray:
+def load_tsv(tsv_fname: str, crs: str=None, units: str=None) -> xr.DataArray:
     """Load a tsv file containing optodes or landmarks.
 
     Parameters
@@ -18,53 +19,103 @@ def load_tsv(tsv_fname: str, crs: str='digitized', units: str='mm') -> xr.DataAr
     tsv_fname : str
         Path to the tsv file.
     crs : str
-        Coordinate reference system of the points.
+        Coordinate reference system of the points if not in the file header.
     units : str
+        Units of the points if not in the file header.
 
     Returns:
     -------
     xr.DataArray
         Optodes or landmarks as a Data
     """
-    with open(tsv_fname, 'r') as f:
-        lines = f.readlines()
-    lines = [line.split() for line in lines]
-
-    data = OrderedDict([(line[0], np.array([float(line[1]), float(line[2]),
-                                            float(line[3])])) for line in lines])
-    # Check if tsv_type is optodes
-    if all([k[0] in ['S', 'D'] for k in data.keys()]):
-        tsv_type = 'optodes'
+    # load the tsv file without header
+    data = pd.read_csv(tsv_fname, sep="\t", header=None)
+    if data.values[0][0] == 'sourceIndex':
+        # tsv file contains a meas_list (with header)
+        return pd.read_csv(tsv_fname, sep="\t")
+    elif data.values[0][0] == 'labels':
+        # tsv file contains a header
+        data = pd.read_csv(tsv_fname, sep="\t")
     else:
-        tsv_type = 'landmarks'
+        data = {'labels': data.iloc[:, 0],
+                'X': data.iloc[:, 1],
+                'Y': data.iloc[:, 2],
+                'Z': data.iloc[:, 3]}
+        
+    for k in data.keys():
+        if k.startswith('crs'):
+            crs = k.split('=')[1].strip()
+            data = data.drop(k, axis=1)
+        if k.startswith('units'):
+            units = k.split('=')[1].strip()
+            data = data.drop(k, axis=1)
+    
+    for k in ['labels', 'X', 'Y', 'Z']:
+        if k not in data.keys():
+            raise ValueError(f"Missing {k} in tsv file")
+   
+    # parse data
+    labels = data['labels'].values
+    data = np.array([data['X'].values, data['Y'].values, data['Z'].values]).T
+   
+    # detect point types
+    types = []
+    for lab in labels:
+        if lab[0] == 'S':
+            types.append(PointType(1)) # sources
+        elif lab[0] == 'D':
+            types.append(PointType(2)) # detectors
+        elif lab in ['NAS', 'Nz', 'Iz', 'LPA', 'RPA']:
+            types.append(PointType(3)) # landmarks
+        elif lab[0] in ['A', 'C', 'F', 'I', 'N', 'O', 'P', 'T']:	
+            types.append(PointType(4)) # electrodes
+        else:
+            raise ValueError("Unknown point type: %s" % lab)
+   
+    # convert to xarray DataArray
+    geo3d = build_labeled_points(data, labels=labels, crs=crs,
+                                 types=types, units=units)
+    return geo3d
 
-    if tsv_type == 'optodes':
-        types = []
-        for lab in data.keys():
-            if lab[0] == 'S':
-                types.append(PointType(1)) # sources
-            elif lab[0] == 'D':
-                types.append(PointType(2)) # detectors
-            else:
-                raise ValueError("Unknown optode type")
 
-        geo3d = build_labeled_points(np.array(list(data.values())),
-                                     labels=list(data.keys()), crs=crs,
-                                     types=types, units=units)
-        return geo3d
-    elif tsv_type == 'landmarks':
-        landmarks = xr.DataArray(
-            np.array(list(data.values())),
-            dims=["label", crs],
-            coords={
-                "label": ("label", list(data.keys())),
-                "type": ("label", [PointType.LANDMARK] * len(data)),
-            },
-            attrs={"units": units},
-        )
-        landmarks = landmarks.pint.quantify()
-        return landmarks
-    return data
+def export_to_tsv(tsv_filename, points):
+    """Export optodes, fiducials, landmarks, electodes, measurement lists to a tsv file.
+
+    Parameters
+    ----------
+    tsv_filename : str
+        Path to the output file.
+
+    points : xr.DataArray, pd.DataFrame
+        Points to save.
+                
+    Returns 
+    -------
+    None    
+    """
+    # if measurement list, save it as tsv using pandas
+    if isinstance(points, pd.DataFrame):
+        points.to_csv(tsv_filename, sep="\t", index=False)
+        return
+    elif isinstance(points, xr.DataArray):
+        # else: types are optodes, fiducials, landmarks, electrodes
+        with open(tsv_filename, 'w') as f:
+            labels = points.label.values
+            header = "labels\tX\tY\tZ"
+            if points.points.crs is not None:
+                header += "\tcrs=%s" % points.points.crs
+            if points.pint.units is not None:
+                if points.pint.units == cedalion.units.mm:
+                    header += "\tunits=mm"
+                else:
+                    header += "\tunits=%s" % points.pint.units
+            f.write(header + "\n")
+            points = np.array(points.to_numpy())
+            for l, p in zip(labels, points):
+                f.write("%s\t%f\t%f\t%f\n" % (l, p[0], p[1], p[2]))
+    else:
+        raise ValueError("Unknown points type: %s" % type(points))
+    return
 
 
 def read_mrk_json(fname: str, crs: str) -> xr.DataArray:

--- a/src/cedalion/plots.py
+++ b/src/cedalion/plots.py
@@ -107,12 +107,14 @@ def plot3d(
     point_colors = {
         PointType.SOURCE: "r",
         PointType.DETECTOR: "b",
-        PointType.LANDMARK: "gray",
+        PointType.LANDMARK: "green",
+        PointType.ELECTRODE: "pink",
     }
     point_sizes = {
         PointType.SOURCE: 3,
         PointType.DETECTOR: 3,
         PointType.LANDMARK: 2,
+        PointType.ELECTRODE: 3,
     }
     if geo3d is not None:
         labels = geo3d.label.values
@@ -319,12 +321,14 @@ def plot_labeled_points(
         PointType.SOURCE: "r",
         PointType.DETECTOR: "b",
         PointType.LANDMARK: "g",
+        PointType.ELECTRODE: "pink",
     }
     default_point_sizes = {
         PointType.UNKNOWN: 2,
         PointType.SOURCE: 3,
         PointType.DETECTOR: 3,
         PointType.LANDMARK: 2,
+        PointType.ELECTRODE: 3,
     }
 
 
@@ -460,12 +464,14 @@ class OptodeSelector:
             PointType.SOURCE: "r",
             PointType.DETECTOR: "b",
             PointType.LANDMARK: "g",
+            PointType.ELECTRODE: "pink",
         }
         default_point_sizes = {
             PointType.UNKNOWN: 2,
             PointType.SOURCE: 3,
             PointType.DETECTOR: 3,
             PointType.LANDMARK: 2,
+            PointType.ELECTRODE: 3,
         }
 
         # points = points.pint.to("mm").pint.dequantify()  # FIXME unit handling

--- a/tests/test_io_probe_geometry.py
+++ b/tests/test_io_probe_geometry.py
@@ -98,6 +98,24 @@ def test_load_tsv_unknown_label_error():
         load_tsv(tsv_path.name)
 
 
+def test_load_tsv_point_type():
+    # Create a TSV with point type 'Fp1'
+    tsv_path = tempfile.NamedTemporaryFile()
+    content = "labels\tX\tY\tZ\tPointType\n" + \
+              "U1\t1\t2\t3\tPointType.OBSCURE\n" + \
+              "S1\t1\t2\t3\tPointType.SOURCE\n" + \
+              "D1\t4\t5\t6\tPointType.DETECTOR\n" + \
+              "RPA\t10\t11\t12\tPointType.LANDMARK\n" + \
+              "Fp1\t7\t8\t9\tPointType.ELECTRODE"
+    with open(tsv_path.name, 'w') as f:
+        f.write(content)
+
+    geo = load_tsv(tsv_path.name)
+    assert isinstance(geo, xr.DataArray)
+    assert list(geo.label.values) == ["U1", "S1", "D1", "RPA", "Fp1"]
+    for i in range(5):
+        assert geo.type.to_numpy()[i] == cdc.PointType(i)
+
 def test_load_tsv_missing_columns():
     # Missing 'Z' column
     tsv_path = tempfile.NamedTemporaryFile()

--- a/tests/test_io_probe_geometry.py
+++ b/tests/test_io_probe_geometry.py
@@ -41,9 +41,9 @@ def test_export_to_tsv_other_points():
         content = f.read()
         lines = content.strip().split('\n')
 
-    assert lines[0] == "labels\tX\tY\tZ\tcrs=ijk\tunits=mm"
-    assert lines[1].startswith("Fp1\t1.000000\t2.000000\t3.000000")
-    assert lines[3].startswith("Cz\t7.000000\t8.000000\t9.000000")
+    assert lines[0] == "labels\tX\tY\tZ\tPointType\tcrs=ijk\tunits=mm"
+    assert lines[1].startswith("Fp1\t1.000000\t2.000000\t3.000000\tPointType.UNKNOWN")
+    assert lines[3].startswith("Cz\t7.000000\t8.000000\t9.000000\tPointType.UNKNOWN")
 
 
 
@@ -85,17 +85,6 @@ def test_load_tsv_without_header():
     assert list(geo.label.values) == ["Fp1", "Fp2"]
     assert geo.points.crs == "RAS"
     assert geo.pint.units == cedalion.units.mm
-
-
-def test_load_tsv_unknown_label_error():
-    # Unknown label type (e.g., starts with 'X')
-    tsv_path = tempfile.NamedTemporaryFile()
-    content = "labels\tX\tY\tZ\nXx1\t1\t2\t3"
-    with open(tsv_path.name, 'w') as f:
-        f.write(content)
-
-    with pytest.raises(ValueError, match="Unknown point type: Xx1"):
-        load_tsv(tsv_path.name)
 
 
 def test_load_tsv_point_type():

--- a/tests/test_io_probe_geometry.py
+++ b/tests/test_io_probe_geometry.py
@@ -1,31 +1,110 @@
 import os
 import tempfile
 import numpy as np
+import pytest
+import pandas as pd
 import xarray as xr
 from numpy.testing import assert_array_almost_equal
 
+import cedalion
 import cedalion.dataclasses as cdc
-from cedalion.io import load_tsv
+from cedalion.io import load_tsv, export_to_tsv
 
 
-def test_load_tsv():
-    # prepare test data
-    num = 10
-    pos = np.random.rand(num, 3)
-    labels = [(np.random.choice(["S%d", "D%d"])) % (i+1) for i in range(num)]
 
-    # write test data to a file
-    dirpath = tempfile.mkdtemp()
-    with open(os.path.join(dirpath, "optodes.tsv"), "w") as f:
-        for l, p in zip(labels, pos):
-            f.write("%s\t%f\t%f\t%f\n" % (l, p[0], p[1], p[2]))
-
-    # call load_tsv to read test data
-    optodes = load_tsv(os.path.join(dirpath, "optodes.tsv"))
-    assert isinstance(optodes, xr.DataArray)
-    assert_array_almost_equal(optodes.pint.dequantify().values, pos)
-    assert sum(optodes.type == cdc.PointType.SOURCE) + \
-           sum(optodes.type == cdc.PointType.DETECTOR) == num
+def test_export_to_tsv_measurement_list():
+    data = np.array([[1,2], [3,4]])
+    meas_list = pd.DataFrame({'sourceIndex': data[:, 0], 'detectorIndex': data[:, 1]})
+    out_file = tempfile.NamedTemporaryFile()
+    export_to_tsv(out_file.name, meas_list)
+    content = pd.read_csv(out_file.name, sep="\t")
+    assert isinstance(content, pd.DataFrame)
+    assert 'sourceIndex' in content.columns
+    assert 'detectorIndex' in content.columns
+    assert len(content) == 2
 
 
+def test_export_to_tsv_other_points():
+    # Create mock data
+    coords = {"dim_0": [0, 1, 2]}
+    data = np.array([[1.0, 2.0, 3.0],
+                     [4.0, 5.0, 6.0],
+                     [7.0, 8.0, 9.0]])
+    points = cdc.build_labeled_points(data, labels=["Fp1", "Fp2", "Cz"], crs="ijk", units="mm")
+
+    # File path to write to
+    out_file = tempfile.NamedTemporaryFile()
+    export_to_tsv(out_file.name, points)
+
+    # Read and validate output
+    with open(out_file.name, 'r') as f:
+        content = f.read()
+        lines = content.strip().split('\n')
+
+    assert lines[0] == "labels\tX\tY\tZ\tcrs=ijk\tunits=mm"
+    assert lines[1].startswith("Fp1\t1.000000\t2.000000\t3.000000")
+    assert lines[3].startswith("Cz\t7.000000\t8.000000\t9.000000")
+
+
+
+def test_load_tsv_with_source_index():
+    # Create a TSV file with sourceIndex in header
+    tsv_path = tempfile.NamedTemporaryFile()
+    content = "sourceIndex\tdetectorIndex\n0\t1\n1\t2"
+    with open(str(tsv_path.name), 'w') as f:
+        f.write(content)
+
+    df = load_tsv(tsv_path.name)
+    assert isinstance(df, pd.DataFrame)
+    assert "sourceIndex" in df.columns
+
+
+def test_load_tsv_with_header_and_metadata():
+    # Create a TSV with header and metadata crs/units
+    tsv_path = tempfile.NamedTemporaryFile()
+    content = "labels\tX\tY\tZ\tcrs=ijk\tunits=mm\nFp1\t1\t2\t3\nFp2\t4\t5\t6"
+    with open(tsv_path.name, 'w') as f:
+        f.write(content)
+
+    geo = load_tsv(tsv_path.name)
+    assert isinstance(geo, xr.DataArray)
+    assert list(geo.label.values) == ["Fp1", "Fp2"]
+    assert geo.points.crs == "ijk"
+    assert geo.pint.units == cedalion.units.mm
+
+
+def test_load_tsv_without_header():
+    # No header, just raw data
+    tsv_path = tempfile.NamedTemporaryFile()
+    content = "Fp1\t1\t2\t3\nFp2\t4\t5\t6"
+    with open(tsv_path.name, 'w') as f:
+        f.write(content)
+
+    geo = load_tsv(tsv_path.name, crs="RAS", units="mm")
+    assert isinstance(geo, xr.DataArray)
+    assert list(geo.label.values) == ["Fp1", "Fp2"]
+    assert geo.points.crs == "RAS"
+    assert geo.pint.units == cedalion.units.mm
+
+
+def test_load_tsv_unknown_label_error():
+    # Unknown label type (e.g., starts with 'X')
+    tsv_path = tempfile.NamedTemporaryFile()
+    content = "labels\tX\tY\tZ\nXx1\t1\t2\t3"
+    with open(tsv_path.name, 'w') as f:
+        f.write(content)
+
+    with pytest.raises(ValueError, match="Unknown point type: Xx1"):
+        load_tsv(tsv_path.name)
+
+
+def test_load_tsv_missing_columns():
+    # Missing 'Z' column
+    tsv_path = tempfile.NamedTemporaryFile()
+    content = "labels\tX\tY\nFp1\t1\t2"
+    with open(tsv_path.name, 'w') as f:
+        f.write(content)
+
+    with pytest.raises(ValueError, match="Missing Z in tsv file"):
+        load_tsv(tsv_path.name)
 


### PR DESCRIPTION
I'm adding here `ELECTRODE` as `PointType(4)`.

Moreover,
- I gave the `cedalion.io.load_tsv` an update to include meas_list (as we discussed to save meas_list, optodes, landmarks and electrodes as tsv by default),
- I added `cedalion.io.export_to_tsv`, such that sharing probes should now be easier! Units and crs are added in the header and read by `load_tsv`. If there's no such information in the header of the file, the user can set it directly by e.g. `load_tsv(filename, units='mm', crs='ijk')`. Default values are `None`, such that the returned xr.DataArray would be returned dimensionless and without crs.
- extended `tests/test_io_probe_geometry.py`.