### PR TITLE
Od2int

### DIFF
--- a/tests/test_nirs.py
+++ b/tests/test_nirs.py
@@ -49,6 +49,12 @@ def test_int2od(ts):
     assert_allclose(od.loc[ch, 850.0, :], [-np.log(1.5), -np.log(1.0), -np.log(0.5)])
 
 
+def test_od2int(ts):
+    od, baseline = cedalion.nirs.int2od(ts, return_baseline = True)
+    amp =  cedalion.nirs.od2int(od, baseline=baseline)
+    assert_allclose(ts, amp, rtol=1e-6, equal_nan=True)
+
+
 def test_od2conc2od():
     rec = cedalion.datasets.get_snirf_test_data()[0]
 


### PR DESCRIPTION
i added functionality and test to go back from OD to amp/intensity space. For this i made a non-breaking change to int2od, which now has an optional baseline variable as output, which is used for OD conversion. There is now the od2int convenience function in .nirs that can take od and baseline to reconstruct the original amp data.
I created it because @theeksnd needed it. I already merged it because its a minor nonbreaking change (i hope), @emiddell fyi.
@lauracarlton might have liked this but i guess now it does not matter anymore (maybe i recall wrongly that you went back all the way to int sometimes).