### PR TITLE
Add showing of plot in image recon multiple view for single timepoint needed for saving plot

### DIFF
--- a/src/cedalion/plots.py
+++ b/src/cedalion/plots.py
@@ -1885,6 +1885,7 @@ def image_recon_multi_view(
                 plot_labeled_points(p0, geo3d_plot)
 
         if SAVE and filename:
+            p0.show()
             p0.screenshot(filename + '.png')
         else:
             p0.show()


### PR DESCRIPTION
Added single line to allow showing of plot in image recon multiple view for single timepoint (pyvista does not allow for screenshots when no plot is shown)