### PR TITLE
Optimize pseudo_inverse_stacked performance: fix double AAt computation and eigenvalue calculation

### DIFF
--- a/src/cedalion/imagereco/solver.py
+++ b/src/cedalion/imagereco/solver.py
@@ -51,10 +51,9 @@ def pseudo_inverse_stacked(
         At = (Linv[:, np.newaxis]**2) * Adot.values.T
     else:  # no spatial regularization
         AAt = Adot.values @ Adot.values.T
-        AAt = Adot.values @ Adot.values.T
         At = Adot.values.T
 
-    highest_eigenvalue = np.linalg.eig(AAt)[0][0].real
+    highest_eigenvalue = np.linalg.norm(AAt, ord=2)
     lambda_meas = alpha * highest_eigenvalue
     if Cmeas is None:
         B = At @ np.linalg.pinv(AAt + lambda_meas * np.eye(AAt.shape[0]))


### PR DESCRIPTION
## Summary
Fixes two major performance bottlenecks in `pseudo_inverse_stacked()` that impact computation time for medium to large matrices.

## Changes
- **Fix double computation**: Remove duplicate `AAt = Adot.values @ Adot.values.T` on lines 37-38
- **Optimize eigenvalue calculation**: Replace full eigendecomposition with matrix 2-norm `np.linalg.eig(AAt)[0][0].real` → `np.linalg.norm(AAt, ord=2)` 

## Related Issues
[Addresses performance concerns with large sensitivity matrices in inverse problem solving.](https://github.com/ibs-lab/cedalion/issues/122)