### PR TITLE
Fix release bug5

### DIFF
--- a/src/cedalion/dot/head_model.py
+++ b/src/cedalion/dot/head_model.py
@@ -440,7 +440,6 @@ class TwoSurfaceHeadModel:
                 os.path.join(foldername, "landmarks.nc")
             )
         self.t_ijk2ras.to_netcdf(os.path.join(foldername, "t_ijk2ras.nc"))
-        self.t_ras2ijk.to_netcdf(os.path.join(foldername, "t_ras2ijk.nc"))
         scipy.sparse.save_npz(os.path.join(foldername, "voxel_to_vertex_brain.npz"),
                                            self.voxel_to_vertex_brain)
         scipy.sparse.save_npz(os.path.join(foldername, "voxel_to_vertex_scalp.npz"),
@@ -460,7 +459,7 @@ class TwoSurfaceHeadModel:
 
         # Check if all files exist
         for fn in ["segmentation_masks.nc", "brain.ply", "scalp.ply",
-                   "t_ijk2ras.nc", "t_ras2ijk.nc", "voxel_to_vertex_brain.npz",
+                   "t_ijk2ras.nc", "voxel_to_vertex_brain.npz",
                    "voxel_to_vertex_scalp.npz"]:
             if not os.path.exists(os.path.join(foldername, fn)):
                 raise ValueError("%s does not exist." % os.path.join(foldername, fn))
@@ -486,7 +485,6 @@ class TwoSurfaceHeadModel:
         else:
             landmarks_ijk = None
         t_ijk2ras = xr.load_dataarray(os.path.join(foldername, 't_ijk2ras.nc'))
-        t_ras2ijk = xr.load_dataarray(os.path.join(foldername, 't_ras2ijk.nc'))
         voxel_to_vertex_brain = scipy.sparse.load_npz(os.path.join(foldername,
                                                      'voxel_to_vertex_brain.npz'))
         voxel_to_vertex_scalp = scipy.sparse.load_npz(os.path.join(foldername,


### PR DESCRIPTION
[t_ras2ijk gets loaded here](https://github.com/ibs-lab/cedalion/blob/dev/src/cedalion/dot/head_model.py#L489) from the folder, but then directly [overwritten by the inverse of t_ijk2ras](https://github.com/ibs-lab/cedalion/blob/dev/src/cedalion/dot/head_model.py#L498): Not really a bug, because ideally they should always be the same, but a bit unclean. 
@emiddell, as discussed, we now store and load only one transform, not both: Fewer files, fewer code, overall cleaner. 