### PR TITLE
Add tests for LandmarksBuilder1010 on a synthetic ellipsoid scalp 

### DIFF
--- a/tests/test_landmarks.py
+++ b/tests/test_landmarks.py
@@ -1,5 +1,7 @@
 """Tests for landmark normalization and visualization functions."""
 
+import warnings
+
 import numpy as np
 import pytest
 import trimesh
@@ -311,3 +313,115 @@ def test_plot_no_canonical_landmarks_present(sample_amp):
 
     # Should not raise, just show no landmarks
     plot_montage3D(sample_amp, geo3d)
+
+
+# Labels emitted by the seven _add_landmarks_along_line calls in
+# LandmarksBuilder1010.build(), plus the five fiducials (Nz/Iz/LPA/RPA + Cz).
+EXPECTED_1010_LABELS = {
+    "Nz", "Iz", "LPA", "RPA", "Cz",
+    # sagittal midline
+    "Fpz", "AFz", "Fz", "FCz", "CPz", "Pz", "POz", "Oz",
+    # coronal midline (T7/T8 added separately)
+    "T7", "T8",
+    # left ear arc
+    "Fp1", "AF7", "F7", "FT7", "TP7", "P7", "PO7", "O1",
+    # right ear arc
+    "Fp2", "AF8", "F8", "FT8", "TP8", "P8", "PO8", "O2",
+    # transverse rows
+    "C5", "C3", "C1", "C2", "C4", "C6",
+    "FC5", "FC3", "FC1", "FC2", "FC4", "FC6",
+    "F5", "F3", "F1", "F2", "F4", "F6",
+    "AF5", "AF3", "AF1", "AF2", "AF4", "AF6",
+    "CP5", "CP3", "CP1", "CP2", "CP4", "CP6",
+    "P5", "P3", "P1", "P2", "P4", "P6",
+    "PO5", "PO3", "PO1", "PO2", "PO4", "PO6",
+}
+
+
+def test_build_constructs_full_1010_system():
+    """End-to-end build() on a synthetic ellipsoid scalp.
+    Exercises build() and _add_landmarks_along_line.
+    """
+    surf, lms = _icosphere_scalp()
+    builder = LandmarksBuilder1010(surf, lms)
+
+    with warnings.catch_warnings():
+        # build() emits a "WIP: distance calculation around ears" UserWarning.
+        warnings.simplefilter("ignore", UserWarning)
+        result = builder.build()
+
+    actual = set(result.label.values.tolist())
+    assert EXPECTED_1010_LABELS.issubset(actual), (
+        f"missing 10-10 labels: {EXPECTED_1010_LABELS - actual}"
+    )
+    assert len(result.label) == len(EXPECTED_1010_LABELS)
+    assert str(result.pint.units) == "millimeter"
+
+    # Geometric value-based assertions on the (85, 100, 90) ellipsoid.
+    coords_mm = result.pint.to("mm").pint.dequantify()
+    pts = {
+        str(label): coords_mm.sel(label=label).values
+        for label in coords_mm.label.values
+    }
+
+    # 1) Every landmark lies on the (85, 100, 90) ellipsoid surface.
+    a, b, c = 85.0, 100.0, 90.0
+    for label, p in pts.items():
+        f = (p[0] / a) ** 2 + (p[1] / b) ** 2 + (p[2] / c) ** 2
+        assert abs(f - 1.0) < 0.05, f"{label} off ellipsoid (f={f:.4f})"
+
+    # 2) Sagittal-midline points have x ~ 0 (cut plane passes through y-axis).
+    sagittal = [
+        "Nz", "Iz", "Cz", "Fpz", "AFz", "Fz", "FCz", "CPz", "Pz", "POz", "Oz",
+    ]
+    for label in sagittal:
+        assert abs(pts[label][0]) < 1.0, (
+            f"{label} not on sagittal plane (x={pts[label][0]:.3f})"
+        )
+
+    # 3) Coronal-midline points have y ~ 0 (cut plane passes through x-axis).
+    coronal = ["Cz", "T7", "T8", "LPA", "RPA"]
+    for label in coronal:
+        assert abs(pts[label][1]) < 1.0, (
+            f"{label} not on coronal plane (y={pts[label][1]:.3f})"
+        )
+
+    # 4) Bilateral (x -> -x) symmetry: the ellipsoid and fiducials are
+    # mirror-symmetric about the y-z plane. The icosphere mesh itself has
+    # icosahedral (not mirror) symmetry, so allow a couple of mm.
+    lr_pairs = [
+        ("T7", "T8"),
+        ("Fp1", "Fp2"), ("AF7", "AF8"), ("F7", "F8"), ("FT7", "FT8"),
+        ("TP7", "TP8"), ("P7", "P8"), ("PO7", "PO8"), ("O1", "O2"),
+        ("C1", "C2"), ("C3", "C4"), ("C5", "C6"),
+        ("FC1", "FC2"), ("FC3", "FC4"), ("FC5", "FC6"),
+        ("F1", "F2"), ("F3", "F4"), ("F5", "F6"),
+        ("AF1", "AF2"), ("AF3", "AF4"), ("AF5", "AF6"),
+        ("CP1", "CP2"), ("CP3", "CP4"), ("CP5", "CP6"),
+        ("P1", "P2"), ("P3", "P4"), ("P5", "P6"),
+        ("PO1", "PO2"), ("PO3", "PO4"), ("PO5", "PO6"),
+    ]
+    for left, right in lr_pairs:
+        pl, pr = pts[left], pts[right]
+        assert abs(pl[0] + pr[0]) < 2.0, f"{left}/{right} x not mirrored"
+        assert abs(pl[1] - pr[1]) < 2.0, f"{left}/{right} y differs"
+        assert abs(pl[2] - pr[2]) < 2.0, f"{left}/{right} z differs"
+
+    # 5) ~10% spacing along the sagittal midline. 11 points -> 10 chord segments.
+    midline_order = [
+        "Nz", "Fpz", "AFz", "Fz", "FCz", "Cz", "CPz", "Pz", "POz", "Oz", "Iz",
+    ]
+    midline = np.array([pts[label] for label in midline_order])
+    segs = np.linalg.norm(np.diff(midline, axis=0), axis=1)
+    assert np.all(np.abs(segs / segs.mean() - 1.0) < 0.10), (
+        f"sagittal midline segments deviate >10% from mean: {segs}"
+    )
+    # Ramanujan upper-half perimeter of the (y/100)^2 + (z/90)^2 = 1 ellipse.
+    ae, be = 100.0, 90.0
+    half_perim = (
+        np.pi * (3 * (ae + be) - np.sqrt((3 * ae + be) * (ae + 3 * be))) / 2
+    )
+    assert abs(segs.sum() - half_perim) / half_perim < 0.05, (
+        f"sagittal chord-sum {segs.sum():.2f} mm vs analytic "
+        f"half-perimeter {half_perim:.2f} mm"
+    )

--- a/tests/test_landmarks.py
+++ b/tests/test_landmarks.py
@@ -2,10 +2,14 @@
 
 import numpy as np
 import pytest
+import trimesh
 import xarray as xr
 
 import cedalion.dataclasses as cdc
-from cedalion.geometry.landmarks import normalize_landmarks_labels
+from cedalion.geometry.landmarks import (
+    LandmarksBuilder1010,
+    normalize_landmarks_labels,
+)
 from cedalion.vis.anatomy.montage import plot_montage3D
 
 
@@ -249,6 +253,39 @@ def test_normalize_then_plot():
 
     # Plot with empty list
     plot_montage3D(amp, normalized_geo3d, landmarks=[])
+
+
+def _icosphere_scalp():
+    """Build a synthetic ellipsoid scalp + canonical Nz/Iz/LPA/RPA fiducials."""
+    sphere = trimesh.creation.icosphere(subdivisions=4, radius=90.0)
+    # squash into a vaguely head-shaped ellipsoid (a, b, c)
+    sphere.vertices = sphere.vertices * np.array([85.0, 100.0, 90.0]) / 90.0
+    surf = cdc.TrimeshSurface(sphere, crs="ras", units="mm")
+
+    landmarks = cdc.build_labeled_points(
+        [
+            [0.0, 100.0, 0.0],   # Nz  (anterior, +y)
+            [0.0, -100.0, 0.0],  # Iz  (posterior, -y)
+            [-85.0, 0.0, 0.0],   # LPA (left, -x)
+            [85.0, 0.0, 0.0],    # RPA (right, +x)
+        ],
+        crs="ras",
+        units="mm",
+        labels=["Nz", "Iz", "LPA", "RPA"],
+        types=[cdc.PointType.LANDMARK] * 4,
+    )
+    return surf, landmarks
+
+
+def test_estimate_cranial_vertex_is_at_apex():
+    """For a head-shaped ellipsoid Cz should sit near the +z apex."""
+    surf, lms = _icosphere_scalp()
+    builder = LandmarksBuilder1010(surf, lms)
+    cz = builder._estimate_cranial_vertex_from_lines()
+    # apex is (0, 0, 90); algorithm averages two close midpoints, should be near apex
+    assert abs(cz[0]) < 5.0
+    assert abs(cz[1]) < 5.0
+    assert cz[2] > 85.0
 
 
 def test_plot_no_canonical_landmarks_present(sample_amp):


### PR DESCRIPTION
Currently working on scaling atlas head models to individuals, and came across missing tests for geometry/landmarks.py. Got crazy using the geodesic distance functionality (still so unreliable, working on it!), so I needed to make sure the lmbuilder at least always works as expected. Using a ellepsoid fake scalp, I added two tests:

**1. test_estimate_cranial_vertex_is_at_apex (commit 4c64d1d)**
  Targets the private helper LandmarksBuilder1010._estimate_cranial_vertex_from_lines, which estimates Cz from the intersection of the sagittal and coronal great‑circle midpoints. On a head‑aligned ellipsoid, the apex is (0, 0,
  90), so the test asserts:
  - |Cz_x| < 5 mm, |Cz_y| < 5 mm
  - Cz_z > 85 mm



**2. test_build_constructs_full_1010_system (commit 21e4a08)**
  Full end‑to‑end run of LandmarksBuilder1010.build(), which internally invokes _add_landmarks_along_line seven times to lay down the sagittal midline, coronal midline, both ear arcs, and the four transverse rows. The test:
  - Suppresses the known "WIP: distance calculation around ears" UserWarning emitted by build(). 
  - Asserts the returned LabeledPoints contains exactly the expected set of 71 10‑10 labels (EXPECTED_1010_LABELS), and is quantified in mm.
  - Performs five independent geometric checks on the result :
    a. On‑surface: every landmark satisfies (x/85)^2 + (y/100)^2 + (z/90)^2 approximately equal 1 to within 5%.
    b. Sagittal plane: Nz, Fpz, AFz, Fz, FCz, Cz, CPz, Pz, POz, Oz, Iz all have |x| < 1 mm.
    c. Coronal plane: Cz, T7, T8, LPA, RPA all have |y| < 1 mm.
    d. Bilateral symmetry: for 30 left/right pairs (T7/T8, Fp1/Fp2, … PO5/PO6), x mirrors and y, z match within 2 mm. The 2 mm slack accounts for the icosphere's icosahedral (non‑mirror) tessellation.
    e. ca. 10% chord spacing along the sagittal midline: the 10 segments between the 11 midline landmarks deviate <10% from their mean, and their sum matches the Ramanujan approximation of the analytic half‑perimeter of the (y/100)^2
  + (z/90)^2 = 1 ellipse to within 5%.
