### PR TITLE
Improve HM scaling to landmarks

### DIFF
--- a/src/cedalion/geometry/registration.py
+++ b/src/cedalion/geometry/registration.py
@@ -5,6 +5,7 @@ from numpy.linalg import pinv
 from scipy.optimize import linear_sum_assignment, minimize
 from scipy.spatial import KDTree
 import xarray as xr
+import warnings
 
 import cedalion
 import cedalion.dataclasses as cdc
@@ -140,6 +141,28 @@ def register_general_affine(
     # restrict to commmon labels and dequantify
     coords_trafo = coords_trafo.sel(label=common_labels).pint.dequantify()
     coords_target = coords_target.sel(label=common_labels).pint.dequantify()
+
+    # Warn if the source landmark cloud (restricted to common labels) is
+    # nearly coplanar — because a 12-DOF affine fit then collapses along the 
+    # plane normal. Threshold 0.20 separates the Nz/Iz/LPA/RPA-only case
+    # (ratio ~0.12, observed 32% z-collapse on colin27) from configurations
+    # that include an off-plane landmark like Cz (ratio ~0.85) or the full
+    # 10-10 set (ratio ~0.7). Ratio numbers stem from experiences after 
+    # extensive testing of different input landmarks on 15 subjects.
+    src_xyz = coords_trafo.values
+    src_centered = src_xyz - src_xyz.mean(axis=0, keepdims=True)
+    sv = np.linalg.svd(src_centered, compute_uv=False)
+    if sv[0] > 0 and sv[-1] / sv[0] < 0.20:
+        warnings.warn(
+            f"register_general_affine: source landmarks are nearly coplanar "
+            f"(sigma_min/sigma_max = {sv[-1]/sv[0]:.3f} on the "
+            f"{len(common_labels)} common labels). The 12-DOF affine fit "
+            f"will be poorly constrained perpendicular to the plane. "
+            f"Consider adding an off-plane landmark (for fNIRS/EEG fiducial "
+            f"sets, Cz works well).",
+            UserWarning,
+            stacklevel=2,
+        )
 
     # Create augmented matrix with homogeneous coordinates
     ones = np.ones((len(common_labels), 1))

--- a/tests/test_dot_forward_model.py
+++ b/tests/test_dot_forward_model.py
@@ -3,6 +3,7 @@ import tempfile
 
 import numpy as np
 import pytest
+import warnings as _warnings
 from scipy.sparse import find
 import sys
 import xarray as xr
@@ -432,3 +433,39 @@ def test_scale_to_landmarks():
     assert (rel_err < 0.05).all(), (
         f"bbox extents differ by {rel_err} (>5%): scaled={s_ext}, target={t_ext}"
     )
+
+
+def _icbm152_target_landmarks_subj_ras(labels):
+    """Helper: pull a subset of icbm152 landmarks into a "subj_ras" mm frame."""
+    icbm = cdot.get_standard_headmodel("icbm152")
+    lm = icbm.landmarks.points.apply_transform(icbm.t_ijk2ras).pint.to("mm")
+    lm = lm.sel(label=lm.label.isin(labels))
+    return lm.rename({lm.points.crs: "subj_ras"})
+
+
+def test_scale_to_landmarks_warns_on_coplanar_fiducials():
+    """4 nearly-coplanar fiducials trigger a coplanarity UserWarning."""
+    target = _icbm152_target_landmarks_subj_ras(["Nz", "Iz", "LPA", "RPA"])
+    colin = cdot.get_standard_headmodel("colin27")
+    with pytest.warns(UserWarning, match="coplanar"):
+        colin.scale_to_landmarks(target)
+
+
+def test_scale_to_landmarks_no_warning_with_cz_added():
+    """Adding Cz lifts the source out of the fiducial plane and silences warning."""
+    target = _icbm152_target_landmarks_subj_ras(["Nz", "Iz", "LPA", "RPA", "Cz"])
+    colin = cdot.get_standard_headmodel("colin27")
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error", UserWarning)
+        colin.scale_to_landmarks(target)
+
+
+def test_scale_to_landmarks_no_warning_full_1010():
+    """Full 10-10 landmark set is well-distributed; no coplanarity warning."""
+    icbm = cdot.get_standard_headmodel("icbm152")
+    target = icbm.landmarks.points.apply_transform(icbm.t_ijk2ras).pint.to("mm")
+    target = target.rename({target.points.crs: "subj_ras"})
+    colin = cdot.get_standard_headmodel("colin27")
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error", UserWarning)
+        colin.scale_to_landmarks(target)

--- a/tests/test_dot_forward_model.py
+++ b/tests/test_dot_forward_model.py
@@ -8,11 +8,11 @@ import sys
 import xarray as xr
 
 import cedalion.data
+import cedalion.dot as cdot
 import cedalion.dot.forward_model as fw
 import cedalion.dataclasses as cdc
 import cedalion.nirs
 import cedalion.xrutils
-
 
 
 try:
@@ -386,3 +386,49 @@ def test_image_to_channel_space():
 
         assert set(ts.dims) == {"channel", "wavelength", "time"}
         assert cedalion.xrutils.check_units(ts, "")
+
+
+def test_scale_to_landmarks():
+    """Round-trip self-consistency for TwoSurfaceHeadModel.scale_to_landmarks.
+
+    Scale colin27 onto icbm152's landmarks, then verify the resulting
+    colin27_scaled.landmarks land near icbm152.landmarks. They should agree
+    within around 5% of head extent.
+    """
+    icbm = cdot.get_standard_headmodel("icbm152")
+    colin = cdot.get_standard_headmodel("colin27")
+
+    # Bring icbm152 landmarks into mm-RAS, then rename CRS dim to avoid
+    # a collision with colin27's "mni" CRS inside register_general_affine.
+    target_lm = icbm.landmarks.points.apply_transform(icbm.t_ijk2ras).pint.to("mm")
+    target_lm = target_lm.rename({target_lm.points.crs: "subj_ras"})
+
+    scaled_colin = colin.scale_to_landmarks(target_lm)
+
+    # After scale_to_landmarks the head model's landmarks already live in the
+    # target frame ("subj_ras"); just convert units for comparison.
+    scaled_lm = scaled_colin.landmarks.pint.to("mm")
+
+    common = sorted(set(scaled_lm.label.values) & set(target_lm.label.values))
+    assert len(common) >= 4, f"need >=4 common labels, got {len(common)}: {common}"
+
+    scaled = scaled_lm.sel(label=common).pint.dequantify().values
+    target = target_lm.sel(label=common).pint.dequantify().values
+
+    diag = float(np.linalg.norm(target.max(0) - target.min(0)))
+    assert 100.0 < diag < 350.0, f"unexpected head diag: {diag} mm"
+
+    resid = np.linalg.norm(scaled - target, axis=1)
+    assert np.median(resid) < 0.05 * diag, (
+        f"median residual {np.median(resid):.2f} mm > 5% of diag {diag:.1f} mm"
+    )
+    assert resid.max() < 0.10 * diag, (
+        f"max residual {resid.max():.2f} mm > 10% of diag {diag:.1f} mm"
+    )
+
+    s_ext = scaled.max(0) - scaled.min(0)
+    t_ext = target.max(0) - target.min(0)
+    rel_err = np.abs(s_ext - t_ext) / t_ext
+    assert (rel_err < 0.05).all(), (
+        f"bbox extents differ by {rel_err} (>5%): scaled={s_ext}, target={t_ext}"
+    )


### PR DESCRIPTION
After extensive testing on 15 subjects, I discovered that calling `TwoSurfaceHeadModel.scale_to_landmarks` with only the four standard fiducials (Nz, Iz, LPA, RPA) produced wildly wrong results — the head collapsed to a flat ellipsoid (e.g., z-axis extent of ~30 mm vs ~150 mm expected). Adding Cz to the input set fixed it.

The underlying issue: register_general_affine in geometry/registration.py fits a 12-DOF affine via least squares from the landmark pairs. Nz/Iz/LPA/RPA all sit nearly on a plane, so that the 12-DOF fit on those nearly-coplanar points is rank-deficient along the plane normal — least-squares produces some answer, but it's poorly constrained perpendicular to the plane, hence the z-collapsed.

I implemented a warning for future users without hard-coding a label-based rule (e.g. "only Nz/Iz/LPA/RPA"), because a well-distributed input — like a full 10-10 EEG set — is perfectly valid and should produce no warning.

A geometric check (check for coplanarity/point spread) within register_general_affine was therefore added using an SVD of the centered 3D source coordinates. If the smallest spatial singular value relative to the largest drops below ~5%, a UserWarning is thrown explaining the problem and suggesting adding an off-plane landmark.

I also added tests to check for the correct behavior of this warning using Colin27 and ICBM-152, with hard-coded ratio thresholds. Those numbers stem from my experiences with the 15-subjects-cohort.
I also added a round-trip test where Colin27 is scaled to the landmarks of the ICBM-152 and the resulting landmarks of the scaled Colin are compared to the landmarks of the ICBM-152.