### PR TITLE
Allow photogrammetry color inspection before process()

### DIFF
--- a/examples/head_models/41_photogrammetric_optode_coregistration.ipynb
+++ b/examples/head_models/41_photogrammetric_optode_coregistration.ipynb
@@ -140,7 +140,13 @@
     "\n",
     "Multiple classes with different colors can be specified. In the following only yellow stickers for class \"O(ptode)\" are searched. But it could be extended to search also for differently colored sticker. (e.g. \"L(andmark)\").\n",
     "\n",
-    "For each sticker the center and the normal is derived. Labels are generated from the class name and a counter, e.g. \"O-01, O-02, ...\""
+    "For each sticker the center and the normal is derived. Labels are generated from the class name and a counter, e.g. \"O-01, O-02, ...\"\n",
+    "\n",
+    "The processor can visualize the scan's vertex colors before running sticker detection.\n",
+    "\n",
+    "The following scatter plot shows the vertex colors in the hue-value plane in which the vertex classification operates. This helps to choose suitable color ranges before calling `process()`.\n",
+    "\n",
+    "The black rectangles illustrate the current classification criteria."
    ]
   },
   {
@@ -156,6 +162,9 @@
     "        #\"L\" : ((0.25, 0.37, 0.35, 0.6))\n",
     "    }\n",
     ")\n",
+    "\n",
+    "preview_details = processor.inspect_colors(surface_mesh)\n",
+    "preview_details.plot_vertex_colors()\n",
     "\n",
     "sticker_centers, normals, details = processor.process(surface_mesh, details=True)\n",
     "display(sticker_centers)"

--- a/src/cedalion/geometry/photogrammetry/processors.py
+++ b/src/cedalion/geometry/photogrammetry/processors.py
@@ -196,17 +196,7 @@ class ColoredStickerProcessor(ScanProcessor):
         """
         assert surface.units == units.mm  # FIXME Einstar yields mm. Allow other units.
 
-        vertex_colors = surface.mesh.visual.to_color().vertex_colors
-
-        rgb_to_hsv = np.vectorize(colorsys.rgb_to_hsv)
-
-        # vertex colors as float HSV values. h,s in [0,1.] v in [0,255]
-        h, s, v = rgb_to_hsv(
-            vertex_colors[:, 0],
-            vertex_colors[:, 1],
-            vertex_colors[:, 2],
-        )
-        v = v / 255.0
+        vertex_colors, h, s, v = self._extract_vertex_color_data(surface)
 
         head_cog = np.mean(surface.mesh.vertices, axis=0)
         radius_mm = float(self.sticker_radius.to("mm").magnitude)
@@ -418,6 +408,39 @@ class ColoredStickerProcessor(ScanProcessor):
         else:
             return sticker_centers, sticker_normals
 
+    def _extract_vertex_color_data(
+        self, surface: cdc.TrimeshSurface
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Return vertex RGB colors together with HSV channels."""
+        vertex_colors = surface.mesh.visual.to_color().vertex_colors
+        rgb_to_hsv = np.vectorize(colorsys.rgb_to_hsv)
+
+        # vertex colors as float HSV values. h,s,v in [0, 1.]
+        h, s, v = rgb_to_hsv(
+            vertex_colors[:, 0],
+            vertex_colors[:, 1],
+            vertex_colors[:, 2],
+        )
+        v = v / 255.0
+
+        return vertex_colors, h, s, v
+
+    def inspect_colors(
+        self, surface: cdc.TrimeshSurface
+    ) -> ColoredStickerProcessorDetails:
+        """Build a details object for color-range inspection without clustering."""
+        vertex_colors, h, s, v = self._extract_vertex_color_data(surface)
+
+        return ColoredStickerProcessorDetails(
+            cluster_coords=[],
+            cluster_circles=[],
+            cluster_colors=[],
+            vertex_colors=vertex_colors,
+            vertex_hue=h,
+            vertex_value=v,
+            cfg_colors=self.colors,
+            vertex_sat=s,
+        )
 
 @cdc.validate_schemas
 def geo3d_from_scan(


### PR DESCRIPTION
Adds an `inspect_colors()` method to the photogrammetry sticker processor so vertex colors can be inspected before running `process()`.

Changes:
- added `ColoredStickerProcessor.inspect_colors(surface)`
- updated the photogrammetry notebook to preview vertex colors before calling `process()`

Users can now do:

```python
preview_details = processor.inspect_colors(surface_mesh)
preview_details.plot_vertex_colors()
```

before running

```python
sticker_centers, normals, details = processor.process(surface_mesh, details=True)
```
Closes #150 