### PR TITLE
fix mutating the input in snap_to_scalp_voxels

### DIFF
--- a/src/cedalion/dot/head_model.py
+++ b/src/cedalion/dot/head_model.py
@@ -621,8 +621,7 @@ class TwoSurfaceHeadModel:
             # Snap to closest scalp voxel
             snapped[i] = voxels[voxel_idx]
 
-        points.values = snapped
-        return points
+        return points.copy(data=snapped)
 
 
     def scale_to_landmarks(


### PR DESCRIPTION
This was a super annoying bug - it took me a bit to identify its cause:

**The problem**
`snap_to_scalp_voxels` takes a DataArray of optode positions (points) and figures out the nearest scalp-voxel coordinate for each. To return the snapped result, it did, but:
```
  points.values = snapped    # overwrite the caller's array in place !!!
  return points              # then hand the same object back
```

**Looks good, what's wrong?**
Writing to .values rewrites my input data! So, even my unsnapped optodes were magically snapped after calling snap_to_scalp_voxels, and an optode location comparison of before and after snapping showed no change at all :exploding_head:

:snake: :snake: :snake: 