### PR TITLE
fix asymmetric TSHM.save() and .load()

### DIFF
--- a/src/cedalion/dot/head_model.py
+++ b/src/cedalion/dot/head_model.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import gzip
+import json
 import os
+import warnings
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -470,6 +472,20 @@ class TwoSurfaceHeadModel:
                                            self.voxel_to_vertex_brain)
         scipy.sparse.save_npz(os.path.join(foldername, "voxel_to_vertex_scalp.npz"),
                                            self.voxel_to_vertex_scalp)
+
+        # PLY drops CRS/units; netCDF doesn't preserve pint units
+        metadata = {
+            "format_version": 1,
+            "brain": {"crs": self.brain.crs, "units": str(self.brain.units)},
+            "scalp": {"crs": self.scalp.crs, "units": str(self.scalp.units)},
+            "t_ijk2ras": {
+                "to_crs":   self.t_ijk2ras.dims[0],
+                "from_crs": self.t_ijk2ras.dims[1],
+                "units":    str(self.t_ijk2ras.pint.units),
+            },
+        }
+        with open(os.path.join(foldername, "metadata.json"), "w") as f:
+            json.dump(metadata, f, indent=2)
         return
 
     @classmethod
@@ -516,12 +532,41 @@ class TwoSurfaceHeadModel:
         voxel_to_vertex_scalp = scipy.sparse.load_npz(os.path.join(foldername,
                                                       'voxel_to_vertex_scalp.npz'))
 
-        # Construct TwoSurfaceHeadModel
-        brain_ijk = cdc.TrimeshSurface(brain, 'ijk', cedalion.units.Unit("1"))
-        scalp_ijk = cdc.TrimeshSurface(scalp, 'ijk', cedalion.units.Unit("1"))
-        t_ijk2ras = cdc.affine_transform_from_numpy(
-            np.array(t_ijk2ras), "ijk", "unknown", "1", "mm"
-        )
+        # PLY drops CRS/units and netCDF doesn't preserve pint units, so the
+        # critical attributes are read from metadata.json written by save().
+        # Alternatively if metadata.json is missing, throw a warning and try to
+        # fall back to inferring the surface CRS from landmarks and assuming
+        # dimensionless units. This is not ideal, since landmarks are optional.
+        metadata_path = os.path.join(foldername, "metadata.json")
+        if os.path.exists(metadata_path):
+            with open(metadata_path) as f:
+                metadata = json.load(f)
+            brain_crs   = metadata["brain"]["crs"]
+            scalp_crs   = metadata["scalp"]["crs"]
+            brain_units = cedalion.units.Unit(metadata["brain"]["units"])
+            scalp_units = cedalion.units.Unit(metadata["scalp"]["units"])
+            t_to_crs    = metadata["t_ijk2ras"]["to_crs"]
+            t_from_crs  = metadata["t_ijk2ras"]["from_crs"]
+            t_units     = cedalion.units.Unit(metadata["t_ijk2ras"]["units"])
+        else:
+            warnings.warn(
+                "Loading head model without metadata.json; "
+                "inferring CRS from landmarks, units assumed dimensionless."
+            )
+            lm_crs = None
+            if landmarks_ijk is not None:
+                lm_crs = next(d for d in landmarks_ijk.dims if d != "label")
+            brain_crs = scalp_crs = lm_crs or "ijk"
+            brain_units = scalp_units = cedalion.units.Unit("1")
+            t_to_crs   = t_ijk2ras.dims[0]
+            t_from_crs = t_ijk2ras.dims[1]
+            t_units    = cedalion.units.Unit("mm")
+
+        brain_ijk = cdc.TrimeshSurface(brain, brain_crs, brain_units)
+        scalp_ijk = cdc.TrimeshSurface(scalp, scalp_crs, scalp_units)
+        t_ijk2ras = xr.DataArray(
+            np.array(t_ijk2ras), dims=[t_to_crs, t_from_crs]
+        ).pint.quantify(t_units)
         t_ras2ijk = xrutils.pinv(t_ijk2ras)
 
         return cls(

--- a/tests/test_dot_forward_model.py
+++ b/tests/test_dot_forward_model.py
@@ -91,6 +91,50 @@ def test_TwoSurfaceHeadModel():
         assert allclose(head.voxel_to_vertex_scalp, head2.voxel_to_vertex_scalp)
 
 
+def test_TwoSurfaceHeadModel_scaled_roundtrip():
+    """save/load must round-trip a head whose CRS is no longer 'ijk'."""
+    (
+        SEG_DATADIR,
+        mask_files,
+        landmarks_file,
+    ) = cedalion.data.get_colin27_segmentation(downsampled=True)
+    head = fw.TwoSurfaceHeadModel.from_segmentation(
+        segmentation_dir=SEG_DATADIR,
+        mask_files=mask_files,
+        landmarks_ras_file=landmarks_file,
+        smoothing=0,
+        brain_face_count=None,
+        scalp_face_count=None,
+    )
+    landmarks_ras = head.landmarks.points.apply_transform(head.t_ijk2ras)
+    # Rename the CRS dim so register_general_affine doesn't see duplicates.
+    target_lm = (landmarks_ras * 1.05).rename(
+        {landmarks_ras.points.crs: "subj_ras"}
+    )
+    scaled = head.scale_to_landmarks(target_lm)
+    assert scaled.crs != "ijk"  # sanity: we actually left ijk
+
+    def iu(x):
+        return x.pint.dequantify().values
+
+    with tempfile.TemporaryDirectory() as dirpath:
+        tmp = os.path.join(dirpath, "scaled_head")
+        scaled.save(tmp)
+        reloaded = fw.TwoSurfaceHeadModel.load(tmp)
+        # Used to raise AssertionError via the crs property.
+        assert reloaded.crs == scaled.crs
+        assert reloaded.brain.crs == scaled.brain.crs
+        assert reloaded.brain.units == scaled.brain.units
+        assert reloaded.scalp.crs == scaled.scalp.crs
+        assert reloaded.scalp.units == scaled.scalp.units
+        assert reloaded.t_ijk2ras.dims == scaled.t_ijk2ras.dims
+        assert (iu(reloaded.t_ijk2ras) == iu(scaled.t_ijk2ras)).all()
+        # landmarks: compare unit-stripped values (netCDF doesn't preserve
+        # pint units, an orthogonal latent issue).
+        assert np.allclose(iu(reloaded.landmarks), iu(scaled.landmarks))
+        repr(reloaded)
+
+
 @skip_if_nirfaster_unavailable
 def test_run_nirfaster():
     """A minimal setup to run nirfaster."""


### PR DESCRIPTION
# Fix `TSHM.load()` losing CRS/units after .save()

## Summary
`save()` and `load()` were asymmetric:
`save()` wrote `brain.ply` / `scalp.ply` via trimesh (PLY drops CRS strings and pint units) while `load()` hardcoded `'ijk'` and `Unit("1")` for both surfaces and also hardcoded the `t_ijk2ras` dim names (`"ijk"→"unknown"`) and units (`"1"→"mm"`).

This basically breaks any head whose CRS has moved out of 'ijk', as a scaled atlas in my case (CRS='aligned').

## Fix
I found no other way then simply writing the CRS/units explicitly via a `metadata.json` so .load() can recover the critical information:
- `save()` writes `metadata.json` with `brain.crs`/`brain.units`, `scalp.crs`/`scalp.units`, and `t_ijk2ras` dim names + composite units.
- `load()` reads `metadata.json`. For legacy folders without it, `load()` infers brain/scalp CRS from `landmarks.nc` (its non-`label` dim is the CRS), assumes dimensionless units, and emits a `UserWarning`. Re-saving the folder once cures it :-)

## Test plan
- Existing `test_TwoSurfaceHeadModel` still passes (unscaled save now also writes `metadata.json` with `crs='ijk'` / `units='dimensionless'`, matching the previous hardcoded values).
- New `test_TwoSurfaceHeadModel_scaled_roundtrip`: scales colin27 to perturbed landmarks, saves, reloads, and asserts CRS/units/dim-names/values match and `repr()` does not raise.


## Backward compatibility
Existing folders without `metadata.json` still load (with a `UserWarning`). Any save now produces the `metadata.json`, so subsequent loads are warning-free.
