### PR TITLE
fix TSHM.scale_to_landmarks dim collapsing bug

### DIFF
--- a/src/cedalion/dot/head_model.py
+++ b/src/cedalion/dot/head_model.py
@@ -663,7 +663,7 @@ class TwoSurfaceHeadModel:
         Args:
             target_landmarks: Target landmark positions (e.g. from a digitizer)
                 in any CRS.  Must contain the same label subset as the model's
-                landmarks.
+                landmarks. 
             mode: method to derive the affine transform. Could be either
                 'trans_rot_isoscale' or 'general'. See cedalion.geometry.registraion
                 for details.
@@ -672,6 +672,20 @@ class TwoSurfaceHeadModel:
             New :class:`TwoSurfaceHeadModel` scaled and aligned to
             ``target_landmarks``.
         """
+        # Avoid CRS-name collisions with self's transform dims. If we don't
+        # rename, the composed t_ijk2scaled ends up with duplicate dim names
+        # (e.g. ["ijk","ijk"]) which xarray cannot broadcast over downstream.
+        # The placeholder is derived from the caller's CRS so the resulting
+        # head model's CRS still points back to the source name.
+        target_crs = target_landmarks.points.crs
+        if target_crs in self.t_ijk2ras.dims:
+            placeholder = f"{target_crs}_scaled"
+            i = 0
+            while placeholder in self.t_ijk2ras.dims:
+                i += 1
+                placeholder = f"{target_crs}_scaled{i}"
+            target_landmarks = target_landmarks.rename({target_crs: placeholder})
+
         if self.crs == "ijk":
             landmarks_ras = self.landmarks.points.apply_transform(self.t_ijk2ras)
         else:
@@ -685,7 +699,7 @@ class TwoSurfaceHeadModel:
             raise ValueError(f"unexpected mode '{mode}'")
 
 
-        t_ijk2scaled = t_ras2scaled @ self.t_ijk2ras
+        t_ijk2scaled = xrutils.compose_affine(t_ras2scaled, self.t_ijk2ras)
         t_scaled2ijk = xrutils.pinv(t_ijk2scaled)
 
         if self.crs == "ijk":
@@ -822,7 +836,9 @@ class TwoSurfaceHeadModel:
         elif voxel_label_crs == "mni305":
             # if the niftii is in mni305 coordiantes apply additionally the transform
             # that bring us from mni305 to mni152
-            ijk2mni152 = cedalion.dot.utils.mni305_to_mni152 @ ijk2crs
+            ijk2mni152 = xrutils.compose_affine(
+                cedalion.dot.utils.mni305_to_mni152, ijk2crs
+            )
 
         ijk2mni152 = ijk2mni152.pint.dequantify()  # FIXME?
 

--- a/src/cedalion/xrutils.py
+++ b/src/cedalion/xrutils.py
@@ -51,6 +51,59 @@ def pinv(array: xr.DataArray) -> xr.DataArray:
     return array_inv
 
 
+def compose_affine(A: xr.DataArray, B: xr.DataArray) -> xr.DataArray:
+    """Compose two affine transforms using the ``[to_crs, from_crs]`` convention.
+
+    Equivalent to numpy ``A @ B``: contracts ``A``'s ``from_crs`` against ``B``'s
+    ``to_crs`` and returns a transform with dims ``[A.dims[0], B.dims[1]]``.
+
+    Using xarray's ``@`` / ``xr.dot`` directly is unsafe here because it
+    contracts over *every* shared dim name, so e.g. composing
+    ``["ijk","mni"]`` with ``["mni","ijk"]`` collapses both dims and returns
+    a scalar instead of a 4x4 matrix.
+
+    Args:
+        A: 4x4 affine transform with dims ``[to_crs_A, from_crs_A]``.
+        B: 4x4 affine transform with dims ``[to_crs_B, from_crs_B]``.
+
+    Returns:
+        4x4 affine transform with dims ``[A.dims[0], B.dims[1]]``. Units are
+        the product of ``A``'s and ``B``'s pint units (so the inner unit
+        cancels for the ``to/from`` convention).
+
+    Raises:
+        ValueError: If either operand is not 2D / 4x4, or if the inner-dim
+            names don't chain (``A.dims[1] != B.dims[0]``).
+    """
+    if A.ndim != 2 or B.ndim != 2:
+        raise ValueError("compose_affine requires 2D DataArrays")
+    if A.shape != (4, 4) or B.shape != (4, 4):
+        raise ValueError(
+            f"compose_affine requires 4x4 transforms, got {A.shape} and {B.shape}"
+        )
+    if A.dims[1] != B.dims[0]:
+        raise ValueError(
+            f"inner dims don't chain: A.dims={A.dims}, B.dims={B.dims}; "
+            f"expected A.dims[1] == B.dims[0]"
+        )
+
+    units_A = A.pint.units
+    units_B = B.pint.units
+    A_vals = A.pint.dequantify().values if units_A is not None else A.values
+    B_vals = B.pint.dequantify().values if units_B is not None else B.values
+
+    result = xr.DataArray(np.matmul(A_vals, B_vals), dims=[A.dims[0], B.dims[1]])
+
+    if units_A is not None and units_B is not None:
+        result = result.pint.quantify(units_A * units_B)
+    elif units_A is not None:
+        result = result.pint.quantify(units_A)
+    elif units_B is not None:
+        result = result.pint.quantify(units_B)
+
+    return result
+
+
 def norm(array: xr.DataArray, dim: str) -> xr.DataArray:
     """Calculate the vector norm along a given dimension.
 

--- a/tests/test_dot_forward_model.py
+++ b/tests/test_dot_forward_model.py
@@ -469,3 +469,28 @@ def test_scale_to_landmarks_no_warning_full_1010():
     with _warnings.catch_warnings():
         _warnings.simplefilter("error", UserWarning)
         colin.scale_to_landmarks(target)
+
+
+def test_scale_to_landmarks_with_colliding_crs_name():
+    """Regression for CRS-name collision in scale_to_landmarks.
+
+    Target_landmarks with a CRS name that collides with the head model's
+    t_ijk2ras dims (e.g. crs="ijk" against an atlas whose t_ijk2ras has dims
+    ["mni","ijk"]) must succeed end-to-end.
+    scale_to_landmarks now internally renames the colliding CRS to a unique
+    placeholder so the result is unambiguous.
+    """
+    colin = cdot.get_standard_headmodel("colin27")
+
+    # Reuse colin's own landmarks (so registration is well-conditioned) but
+    # force the CRS dim name to "ijk" so it collides with colin.t_ijk2ras.dims.
+    target = colin.landmarks.points.apply_transform(colin.t_ijk2ras).pint.to("mm")
+    target = target.rename({target.points.crs: "ijk"})
+    assert "ijk" in colin.t_ijk2ras.dims  # precondition for the collision
+
+    scaled = colin.scale_to_landmarks(target)
+
+    assert scaled.t_ijk2ras.ndim == 2
+    assert scaled.t_ijk2ras.shape == (4, 4)
+    assert scaled.t_ras2ijk.shape == (4, 4)
+    assert len(set(scaled.t_ijk2ras.dims)) == 2  # no duplicate dim names

--- a/tests/test_xrutils.py
+++ b/tests/test_xrutils.py
@@ -5,6 +5,7 @@ import xarray as xr
 from scipy.sparse import csr_matrix
 
 import cedalion
+import cedalion.dataclasses as cdc
 import cedalion.xrutils as xrutils
 
 
@@ -160,6 +161,48 @@ def test_unit_stripping_is_error():
 
     with pytest.warns(pint.errors.UnitStrippedWarning):
         a.values
+
+
+def test_compose_affine_with_colliding_outer_dims():
+    """Regression for the head_model.scale_to_landmarks scalar collapse.
+
+    xr `@`/`xr.dot` collapses to a scalar when both outer dim names also
+    appear as inner dims. compose_affine must produce a 4x4 matrix matching
+    numpy matmul.
+    """
+    rng = np.random.default_rng(0)
+    A_np = rng.normal(size=(4, 4))
+    B_np = rng.normal(size=(4, 4))
+
+    A = cdc.affine_transform_from_numpy(
+        A_np, from_crs="mni", to_crs="ijk", from_units="mm", to_units="mm"
+    )
+    B = cdc.affine_transform_from_numpy(
+        B_np, from_crs="ijk", to_crs="mni", from_units="mm", to_units="mm"
+    )
+
+    # sanity: xr `@` does the wrong thing here (collapses both shared dims)
+    bad = A @ B
+    assert bad.shape == ()
+
+    composed = xrutils.compose_affine(A, B)
+
+    assert composed.shape == (4, 4)
+    # outer dims here happen to both be "ijk" (the to_crs of A and from_crs of B);
+    # what matters is that the values are a real 4x4 matmul, not a scalar.
+    assert composed.dims == ("ijk", "ijk")
+    np.testing.assert_allclose(composed.pint.dequantify().values, A_np @ B_np)
+
+
+def test_compose_affine_inner_dims_mismatch():
+    A = cdc.affine_transform_from_numpy(
+        np.eye(4), from_crs="mni", to_crs="ijk", from_units="mm", to_units="mm"
+    )
+    B = cdc.affine_transform_from_numpy(
+        np.eye(4), from_crs="ras", to_crs="aligned", from_units="mm", to_units="mm"
+    )
+    with pytest.raises(ValueError, match="inner dims"):
+        xrutils.compose_affine(A, B)
 
 
 def test_unit_stripping_is_quiet(recwarn):


### PR DESCRIPTION
# Fix `TSHM.scale_to_landmarks` dim collapse bug

## Summary

`scale_to_landmarks()` silently produced a broken transform whenever the caller's `target_landmarks` used a CRS name that already appeared in the head model's `t_ijk2ras` dim names (e.g. user fiducials with `crs="ijk"` scaling a standard atlas whose `t_ijk2ras` has dims `["mni","ijk"]`).

Root cause: `t_ras2scaled @ self.t_ijk2ras` at `src/cedalion/dot/head_model.py:688` used **xarray's @ operator, which contracts over every shared dim name** — not just the inner dim like numpy `matmul`. With dims `["ijk","mni"]` and `["mni","ijk"]`, both were contracted and the result collapsed to a 0-d scalar, after which `xrutils.pinv` and the rest of the pipeline operated on garbage.


## Changes

- **New utility:** `cedalion.xrutils.compose_affine(A, B)` — composes two affine transforms with the cedalion `[to_crs, from_crs]` convention via `np.matmul`, validates the inner-dim chain, and propagates pint units. Use this instead of `@` whenever composing affine `xr.DataArray`s.
- **`src/cedalion/dot/head_model.py:688`:** swap the buggy `@` for `xrutils.compose_affine`.
- **`src/cedalion/dot/head_model.py:825`:** same swap for the `mni305 → mni152` composition (safe today, switched for consistency).
- **`scale_to_landmarks`:** at the top of the function, detect when `target_landmarks.points.crs` collides with a dim of `self.t_ijk2ras` and rename the target CRS to a unique placeholder derived from the caller's name (`"ijk"` → `"ijk_scaled"`, with a numeric suffix if `"ijk_scaled"` also collides). Non-colliding callers see no change; the resulting head model's CRS is still traceable back to the input.

## Testing

- New unit tests in `tests/test_xrutils.py`:
  - `test_compose_affine_with_colliding_outer_dims` — explicitly verifies that `xr.@` collapses to a scalar on the colliding case and that `compose_affine` returns a correct 4×4.
  - `test_compose_affine_inner_dims_mismatch` — clear `ValueError` when the chain doesn't match.
- New regression test in `tests/test_dot_forward_model.py::test_scale_to_landmarks_with_colliding_crs_name` — end-to-end `scale_to_landmarks` against an atlas with a CRS-name collision now succeeds and returns a head model with shape-(4,4), distinct-dim transforms.
