### PR TITLE
fix photogrammetry CRS to "digitized"

### DIFF
--- a/src/cedalion/io/photogrammetry.py
+++ b/src/cedalion/io/photogrammetry.py
@@ -68,8 +68,7 @@ def opt_fid_to_xr(fiducials, optodes):
                 object.
     """
 
-    # FIXME: this should get a different CRS
-    CRS = "ijk"
+    CRS = "digitized"
     if len(fiducials) == 0:
         fidu_coords = np.zeros((0, 3))
     else:

--- a/tests/test_io_photogrammetry.py
+++ b/tests/test_io_photogrammetry.py
@@ -44,6 +44,9 @@ def test_opt_fid_to_xr():
             else:
                 assert opt.shape == (0, 3)
 
+            assert fid.points.crs == "digitized"
+            assert opt.points.crs == "digitized"
+
             assert (opt.type == cdc.PointType.SOURCE).all()
             optodes = {l.replace("S", "D"): o for l, o in optodes.items()}
             fid, opt = opt_fid_to_xr(fiducials, optodes)
@@ -63,6 +66,8 @@ def test_read_photogrammetry_einstar():
     assert_array_almost_equal(opt.values, optodes)
     assert sum(opt.type == cdc.PointType.SOURCE) == 10
     assert sum(opt.type == cdc.PointType.DETECTOR) == 90
+    assert fid.points.crs == "digitized"
+    assert opt.points.crs == "digitized"
 
 
 def write_test_photo_fn(fid, opt):


### PR DESCRIPTION
read_photogrammetry_einstar was tagging fiducials and optodes with crs="ijk" (a FIXME'd placeholder), while we meanwhile agreead on the CRS "digitized" (see e.g. read_einstar_obj returns the paired mesh as crs="digitized").

So, this switches opt_fid_to_xr to crs="digitized" and adds test assertions.