### PR TITLE
remove unused code line

### DIFF
--- a/src/cedalion/io/probe_geometry.py
+++ b/src/cedalion/io/probe_geometry.py
@@ -176,8 +176,6 @@ def read_mrk_json(fname: str, crs: str) -> xr.DataArray:
     if len(unique_units) > 1:
         raise ValueError(f"more than one unit found in {fname}: {unique_units}")
 
-    pos = np.vstack(pos)
-
     result = xr.DataArray(
         positions,
         dims=["label", crs],


### PR DESCRIPTION
`pos = np.vstack(pos)` removed. `pos` is anyway not returned. Looks like a leftover from an old implementation/refactoring