### PR TITLE
update Dockerfile as the old one was somehow working but not really optimal

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# Build context for the cedalion docker image (see Dockerfile).
+#
+# NOTE: .git is deliberately NOT excluded. pyproject.toml uses hatch-vcs, so
+# `pip install -e .` derives cedalion's version from the git metadata and fails
+# without it.
+
+.github/
+.vscode/
+.idea/
+
+# build, test and documentation artefacts
+build/
+dist/
+*.egg-info/
+docs/_build/
+.pytest_cache/
+.coverage
+htmlcov/
+.ruff_cache/
+.mypy_cache/
+__pycache__/
+*.py[cod]
+.ipynb_checkpoints/
+
+# downloaded by install_nirfaster.sh inside the image
+plugins/
+
+# container definitions are not needed inside the image
+Dockerfile
+.dockerignore
+cedalion.def

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,75 +1,102 @@
-### continuumio/miniconda3 but with debian:12-slim as base image
-FROM debian:12-slim
+###############################################################################
+# cedalion development environment
+#
+#   docker build -t cedalion .
+#   docker run -it --rm cedalion                              # shell in the env
+#   docker run -it --rm -p 8888:8888 cedalion \
+#       jupyter notebook --ip 0.0.0.0 --no-browser --allow-root
+#
+# Optional photon transport solver (see install_nirfaster.sh):
+#   docker build -t cedalion --build-arg INSTALL_NIRFASTER=CPU .
+###############################################################################
 
-ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+# environment_dev.yml declares conda-forge as its only channel, so miniforge is
+# the matching base image. It is also the conda distribution used by CI
+# (.github/workflows/run_tests.yml).
+ARG CONDA_IMAGE=condaforge/miniforge3:26.3.2-3
+FROM ${CONDA_IMAGE}
 
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    DEBIAN_FRONTEND=noninteractive \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# git          - hatch-vcs derives cedalion's version from it during the install
+# libgl*/libx* - runtime libraries of VTK and pyvista
+# xvfb, xauth  - offscreen rendering. xvfb-run needs xauth, which the xvfb
+#                package only recommends and which --no-install-recommends
+#                therefore skips.
+# curl, unzip  - used by install_nirfaster.sh
 # hadolint ignore=DL3008
 RUN apt-get update -q && \
     apt-get install -q -y --no-install-recommends \
-        bzip2 \
         ca-certificates \
+        curl \
         git \
+        libgl1 \
+        libgl1-mesa-dri \
         libglib2.0-0 \
+        libglx-mesa0 \
         libsm6 \
         libxext6 \
+        libxkbcommon0 \
         libxrender1 \
-        mercurial \
         openssh-client \
         procps \
-        subversion \
-        wget \
+        unzip \
+        xauth \
+        xvfb \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ENV PATH=/opt/conda/bin:$PATH
+WORKDIR /cedalion
 
-CMD [ "/bin/bash" ]
+# The conda environment is created before the source tree is copied, so that
+# editing cedalion does not invalidate this expensive layer.
+#
+# environment_dev.yml ends with an editable install of ./workflows, resolved
+# relative to the working directory, so that directory is needed here as well.
+# conda in miniforge resolves with the libmamba solver by default.
+COPY environment_dev.yml ./
+COPY workflows ./workflows
+RUN conda env create -n cedalion -f environment_dev.yml && \
+    conda clean -afy && \
+    find /opt/conda/ -follow -type f -name '*.a' -delete
 
-# Leave these args here to better use the Docker build cache
-ARG CONDA_VERSION=py311_24.1.2-0
+# Put the environment first on PATH, so that python/pip/pytest also resolve in
+# non-interactive calls such as `docker exec`. Interactive shells additionally
+# get a full `conda activate` from .bashrc.
+ENV PATH=/opt/conda/envs/cedalion/bin:${PATH}
+RUN echo "conda activate cedalion" >> /root/.bashrc
 
-RUN set -x && \
-    UNAME_M="$(uname -m)" && \
-    if [ "${UNAME_M}" = "x86_64" ]; then \
-        MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh"; \
-        SHA256SUM="3f2e5498e550a6437f15d9cc8020d52742d0ba70976ee8fce4f0daefa3992d2e"; \
-    elif [ "${UNAME_M}" = "s390x" ]; then \
-        MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-s390x.sh"; \
-        SHA256SUM="0489909051fd9e2c9addfa5fbd531ccb7f8f2463ac47376b8854e5a09b1c4011"; \
-    elif [ "${UNAME_M}" = "aarch64" ]; then \
-        MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-aarch64.sh"; \
-        SHA256SUM="1e046ef2d9d47289db2491f103c81b0b4baf943a9234ac59bd5bca076c881d98"; \
-    fi && \
-    wget "${MINICONDA_URL}" -O miniconda.sh -q && \
-    echo "${SHA256SUM} miniconda.sh" > shasum && \
-    if [ "${CONDA_VERSION}" != "latest" ]; then sha256sum --check --status shasum; fi && \
-    mkdir -p /opt && \
-    bash miniconda.sh -b -p /opt/conda && \
-    rm miniconda.sh shasum && \
-    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
-    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
-    echo "conda activate base" >> ~/.bashrc && \
-    find /opt/conda/ -follow -type f -name '*.a' -delete && \
-    find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
-    /opt/conda/bin/conda clean -afy
+# The source tree is copied last. .git is deliberately included (see
+# .dockerignore): hatch-vcs needs it to write src/cedalion/_version.py.
+COPY . .
+RUN pip install --no-cache-dir -e . --no-deps && \
+    python -c "import cedalion; print('cedalion', cedalion.__version__)"
 
+# Optional: NIRFASTer, the photon propagator used by cedalion.dot.forward_model
+# that also runs on the CPU.
+ARG INSTALL_NIRFASTER=""
+RUN if [ -n "${INSTALL_NIRFASTER}" ]; then \
+        bash install_nirfaster.sh "${INSTALL_NIRFASTER}"; \
+    fi
 
+# pyvista renders offscreen against the Xvfb server that the entrypoint starts
+# on this display.
+ENV DISPLAY=:99 \
+    PYVISTA_OFF_SCREEN=true
 
+EXPOSE 8888
 
-### cedalion 
-ADD . /cedalion
-
-# Create environment
-RUN apt-get update && apt-get install -qq -y \
-        libgl1 \
-    && cd /cedalion \
-    && conda env create -n cedalion -f environment_dev.yml 
-
-# Make RUN commands to always use cedalion environment
-SHELL ["conda", "run", "-n", "cedalion", "/bin/bash", "-c"]
-    
-# Install cedalion
-RUN pip3 install -e /cedalion
-
-# Activate cedalion env on interactive shell startup
-RUN echo "conda activate cedalion" >> ~/.bashrc
+# Start an X virtual framebuffer, which pyvista's 3D plotting needs in a
+# headless container, and then hand the command PID 1 with `exec`, so that it
+# receives the TTY and signals such as `docker stop`. cedalion.def does the
+# equivalent for Apptainer.
+#
+# Xvfb is started directly rather than through xvfb-run: as an entrypoint, that
+# is PID 1, xvfb-run hung waiting for the SIGUSR1 readiness handshake with Xvfb,
+# and its default error file of /dev/null hid the reason. Errors are kept in
+# /tmp/xvfb.log here. Bypass the entrypoint with `--entrypoint ""`.
+ENTRYPOINT ["/bin/sh", "-c", "Xvfb \"$DISPLAY\" -screen 0 1024x768x24 >/tmp/xvfb.log 2>&1 & sleep 1; exec \"$@\"", "--"]
+CMD ["bash"]

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -234,7 +234,43 @@ $ apptainer run --nv --bind `pwd`/xkb:/var/lib/xkb,`pwd`/cedalion:/app cedalion.
 
 ### Docker
 
-Build the image from the repo root with `docker build -t cedalion .`, which copies the
-local source tree into the image and installs it into a conda environment using
-environment_dev.yml. Run it interactively with `docker run -it cedalion bash`, which
-drops you into a shell with the Cedalion conda environment automatically activated.
+The `Dockerfile` in the repository root builds an image that contains the conda
+environment described by `environment_dev.yml`, cedalion installed in editable mode and
+an X virtual framebuffer for pyvista's 3D plotting.
+
+Build the image from the repository root:
+
+```
+$ docker build -t cedalion .
+```
+
+To additionally install the NIRFASTer photon propagator (see step 6 above):
+
+```
+$ docker build -t cedalion --build-arg INSTALL_NIRFASTER=CPU .
+```
+
+Run an interactive shell with the `cedalion` environment activated:
+
+```
+$ docker run -it --rm cedalion
+```
+
+Run a jupyter notebook server and open it at the URL that is printed:
+
+```
+$ docker run -it --rm -p 8888:8888 cedalion \
+    jupyter notebook --ip 0.0.0.0 --no-browser --allow-root
+```
+
+To work on the source code from the host, mount your clone over `/cedalion`. The editable
+install picks the changes up:
+
+```
+$ docker run -it --rm -v `pwd`:/cedalion -p 8888:8888 cedalion
+```
+
+The entrypoint starts an X virtual framebuffer on `DISPLAY=:99`, so that pyvista renders
+offscreen without further setup. Shells opened with `docker exec` inherit that display and
+can render too. Should 3D plotting fail, the output of the X server is kept in
+`/tmp/xvfb.log` inside the container.


### PR DESCRIPTION
### Main Improvements
- Base image: changed from miniconda to condaforge/miniforge3 (as used by CI).
- OpenCV: problems solved - it is now installed the way the docs and CI do.
- Layer order: the conda environment is created before the source tree is copied, so editing cedalion no longer invalidates the multi-GB solve.
- Plotting: pyvista supported
- Build context: .dockerignore is added; .git stays in the context because hatch-vcs needs it for the version.

### Testing
```
docker build -t cedalion --build-arg INSTALL_NIRFASTER=CPU .
docker run -it --rm cedalion
docker run --rm cedalion python -m pytest
```

1. NIRFASTer is found.  test_run_nirfaster  skips silently when the import fails, so check
it reports PASSED rather than SKIPPED:
```
docker run --rm cedalion ls plugins/nirfaster-uFF
docker run --rm cedalion python -m pytest tests/test_dot_forward_model.py::test_run_nirfaster -v
```

2. Only one OpenCV, from conda:
```
docker run --rm cedalion pip list | grep -i opencv
docker run --rm cedalion python -c "import cv2; print(cv2.__file__)"
```

3. The version comes from hatch-vcs, i.e.  .git  reached the build:
```
docker run --rm cedalion python -c "import cedalion; print(cedalion.__version__)"
```

4. 3D plotting renders offscreen ( -v  keeps the downloaded atlas around):
```
docker run --rm -v cedalion-cache:/root/.cache cedalion python -c "
import pyvista as pv
from cedalion.dot.head_model import get_standard_headmodel
from cedalion.vis.blocks import plot_surface
hm = get_standard_headmodel('colin27')
pl = pv.Plotter(off_screen=True)
plot_surface(pl, hm.brain)
pl.show(screenshot='/tmp/brain.png')
print('ok')"
```

5. Jupyter, headless and interactive:
```
docker run --rm cedalion jupyter nbconvert --execute --to notebook --stdout \
    examples/getting_started_io/00_test_installation.ipynb > /dev/null
docker run -it --rm -p 8888:8888 cedalion \
    jupyter notebook --ip 0.0.0.0 --no-browser --allow-root
```