### PR TITLE
normalize the spatial prior per brain/scalp compartment seperately

### DIFF
--- a/src/cedalion/dot/image_recon.py
+++ b/src/cedalion/dot/image_recon.py
@@ -26,6 +26,7 @@ from cedalion.dot.head_model import TwoSurfaceHeadModel
 logger = logging.getLogger("cedalion")
 
 ReconMode = Literal["conc", "mua", "mua2conc"]
+SpatialNormalization = Literal["global", "per_compartment"]
 
 # predefined parameter sets
 
@@ -986,6 +987,16 @@ class ImageRecon:
             rescaled. A smaller alpha_spatial will more strongly suppress activation
             that is reconstructed on the scalp.
 
+        spatial_normalization: selects the compartment over which the maximum
+            sensitivity that scales alpha_spatial is taken.
+
+            - 'global': one maximum over all vertices (scalp and brain together).
+            - 'per_compartment': brain and scalp vertices are normalized separately,
+                each by the maximum sensitivity of its own compartment.
+
+            Ignored when alpha_spatial is None, and inconsequential when
+            brain_only is True, since then only one compartment is present.
+
         lambda_R_conc: regularization parameter that sets the expected magnitude of the
             image covariance.
 
@@ -1002,6 +1013,7 @@ class ImageRecon:
         *,
         alpha_meas: float = 0.001,
         alpha_spatial: float | None = None,
+        spatial_normalization: SpatialNormalization = "global",
         lambda_R_conc: float | None = None,
         apply_c_meas: bool = False,
         recon_mode: ReconMode = "mua",
@@ -1015,6 +1027,11 @@ class ImageRecon:
             raise ValueError(
                 "recon_mode must be set to either 'conc', 'mua' or 'mua2conc'!"
             )
+        if spatial_normalization not in ["global", "per_compartment"]:
+            raise ValueError(
+                "spatial_normalization must be set to either 'per_compartment' or "
+                "'global'!"
+            )
         # error handling of invalid params
 
         self.recon_mode = recon_mode
@@ -1022,6 +1039,7 @@ class ImageRecon:
         # regularization parameters
         self.alpha_meas = alpha_meas
         self.alpha_spatial = alpha_spatial
+        self.spatial_normalization = spatial_normalization
         self.apply_c_meas = apply_c_meas
         self.lambda_R_conc = lambda_R_conc
 
@@ -1267,11 +1285,25 @@ class ImageRecon:
         """
 
         B = np.sum((A**2), axis=0)
-        b = B.max()
 
         if self.alpha_spatial is None:
             lambda_spatial = 1.
+        elif self.spatial_normalization == "global":
+            b = B.max()
+            lambda_spatial = self.alpha_spatial * b
         else:
+            # Normalize per compartment. Brain and scalp sensitivities differ by ~6
+            # orders of magnitude, so a single global max is set by the scalp and makes
+            # lambda_spatial constant across all brain vertices, disabling depth
+            # weighting there. NeuroDOT's global max is a brain max only because its A
+            # carries no scalp compartment.
+            is_brain = A.is_brain.values.astype(bool)
+            Bv = B.values
+            if is_brain.all() or not is_brain.any():
+                b = Bv.max()
+            else:
+                b = np.where(is_brain, Bv[is_brain].max(), Bv[~is_brain].max())
+
             lambda_spatial = self.alpha_spatial * b
 
         L = np.sqrt(B + lambda_spatial)

--- a/tests/test_dot_image_recon.py
+++ b/tests/test_dot_image_recon.py
@@ -1,5 +1,6 @@
 import cedalion.data
 import cedalion.dot as dot
+import cedalion.dot.forward_model as fwm
 import cedalion.typing as cdt
 import numpy as np
 import xarray as xr


### PR DESCRIPTION
## Problem
When scalp vertices are present in Adot, they exceed the brain by orders of magnitude and set alpha_spatial's scaling for both compartments, which makes the spatial prior nearly constant over the brain and effectively disables depth weighting
there:

```
"""Dynamic range of the SVR prior R over brain and scalp, shown on the fingertapping Adot."""
import numpy as np
import cedalion.data
import cedalion.dot as dot
import cedalion.dot.forward_model as fw

Adot = cedalion.data.get_precomputed_sensitivity("fingertappingDOT", "colin27")
A = fw.ForwardModel.compute_stacked_sensitivity(Adot, "prahl")
brain = np.asarray(A.is_brain.values).astype(bool)
B = np.asarray((A**2).sum("flat_channel").values)

print(f"max(B) brain {B[brain].max():.3e}   scalp {B[~brain].max():.3e}")
print(f"{'alpha_spatial':>13} {'R range brain':>14} {'R range scalp':>14}")

for alpha in [1.0, 0.1, 1e-2, 1e-3]:
    R = np.asarray(
        dot.ImageRecon(
            Adot=Adot,
            recon_mode="conc",
            alpha_meas=0.01,
            alpha_spatial=alpha,
            #spatial_normalization="global",
        )._calculate_prior_R(A)
    )
    print(
        f"{alpha:>13.0e}"
        f" {R[brain].max() / R[brain].min():>14.3f}"
        f" {R[~brain].max() / R[~brain].min():>14.3f}"
    )
```
**Output:**
```
max(B) brain 6.400e+05   scalp 8.847e+08
alpha_spatial  R range brain  R range scalp
        1e+00          1.001          2.000
        1e-01          1.007         11.000
        1e-02          1.072        101.000
        1e-03          1.723       1001.000
```

## Literature

- [Niu, Lin, Tian, Dhamne & Liu (2010), J. Biomed. Opt. 15:046005](https://www.spiedigitallibrary.org/journals/journal-of-biomedical-optics/volume-15/issue-4/046005/Comprehensive-investigation-of-three-dimensional-diffuse-optical-tomography-with-depth/10.1117/1.3462986.full). The depth compensation algorithm builds its weighting from layer-wise maximum singular values, M = {diag[M(A_l), ..., M(A_1)]}^γ, so the normalizer is computed within a layer rather than globally.
- [Zhan, Eggebrecht, Culver & Dehghani (2012), Front. Neuroenergetics 4:6](https://www.frontiersin.org/journals/neuroenergetics/articles/10.3389/fnene.2012.00006/full). Segments the Jacobian into J_b (white and gray matter) and J_nb (CSF, skull, scalp), and states that "J_b can be used instead of J_h in the spatial-regularization step".
- `_calculate_prior_R` matches NeuroDOT's `Tikhonov_invert_Amat.m` exactly (ll = sqrt(sum(A.^2,1) + lambda2*max(sum(A.^2,1)))), but in NeuroDOT the scalp never enters A, so the single global max is a brain max.



## Change

   New `ImageRecon(spatial_normalization=...)`, `"global"` by default for current behavior, `"per_compartment"` taking the max over each compartment separately, using the `is_brain` coordinate.


   ## Compatibility
   
**This changes reconstructions for no one silently, as by default `spatial_normalization="global"`, which reproduces the current results.**